### PR TITLE
feat: add academic queries and export screens

### DIFF
--- a/src/academic/application/usecases/UseCase.ts
+++ b/src/academic/application/usecases/UseCase.ts
@@ -5,9 +5,9 @@ export interface UseCase<T, C extends UseCaseCommand> {
     execute(command: C): Promise<Either<Failure[], T | undefined>>;
 }
 
-export type UseCaseCommand = { }
+export type UseCaseCommand = object;
 
-export class EmptyUseCaseCommand implements UseCaseCommand { }
+export class EmptyUseCaseCommand implements UseCaseCommand {}
 
 export class PaginateUseCaseCommand implements UseCaseCommand {
     constructor(
@@ -15,14 +15,14 @@ export class PaginateUseCaseCommand implements UseCaseCommand {
         private perPage: number,
         private orderBy: string[],
         private where?: string,
+    ) {}
 
-    ) { }
     get data() {
         return {
             page: this.page,
             perPage: this.perPage,
             search: this.where,
-            orderBy: this.orderBy
+            orderBy: this.orderBy,
         };
     }
 }

--- a/src/academic/application/usecases/representative/CreateRepresentativeUseCase.ts
+++ b/src/academic/application/usecases/representative/CreateRepresentativeUseCase.ts
@@ -9,7 +9,15 @@ import { REPRESENTATIVE_SYMBOLS } from "@/academic/domain/symbols/Representative
 export class CreateRepresentativeCommand implements UseCaseCommand {
     constructor(
         public readonly firstName: string,
-        public readonly lastName: string
+        public readonly lastName: string,
+        public readonly phone?: string,
+        public readonly birthDate?: string,
+        public readonly uuidUser?: string,
+        public readonly address?: string,
+        public readonly identification?: string,
+        public readonly nacionality?: string,
+        public readonly gender?: string,
+        public readonly image?: string,
     ) { }
 }
 
@@ -22,7 +30,19 @@ export class CreateRepresentativeUseCase implements UseCase<Representative, Crea
 
     async execute(command: CreateRepresentativeCommand): Promise<Either<AbstractFailure[], Representative | undefined>> {
         try {
-            const rep = new Representative(0, command.firstName, command.lastName);
+            const rep = new Representative(
+                0,
+                command.firstName,
+                command.lastName,
+                command.phone,
+                command.birthDate,
+                command.uuidUser,
+                command.address,
+                command.identification,
+                command.nacionality,
+                command.gender,
+                command.image,
+            );
             const created = await this.service.create(rep);
             return Right(created);
         } catch (error) {

--- a/src/academic/application/usecases/representative/UpdateRepresentativeUseCase.ts
+++ b/src/academic/application/usecases/representative/UpdateRepresentativeUseCase.ts
@@ -10,7 +10,15 @@ export class UpdateRepresentativeCommand implements UseCaseCommand {
     constructor(
         public readonly id: number,
         public readonly firstName?: string,
-        public readonly lastName?: string
+        public readonly lastName?: string,
+        public readonly phone?: string,
+        public readonly birthDate?: string,
+        public readonly uuidUser?: string,
+        public readonly address?: string,
+        public readonly identification?: string,
+        public readonly nacionality?: string,
+        public readonly gender?: string,
+        public readonly image?: string,
     ) { }
 }
 
@@ -23,7 +31,19 @@ export class UpdateRepresentativeUseCase implements UseCase<Representative, Upda
 
     async execute(command: UpdateRepresentativeCommand): Promise<Either<AbstractFailure[], Representative | undefined>> {
         try {
-            const rep = new Representative(command.id, command.firstName ?? "", command.lastName ?? "");
+            const rep = new Representative(
+                command.id,
+                command.firstName ?? "",
+                command.lastName ?? "",
+                command.phone,
+                command.birthDate,
+                command.uuidUser,
+                command.address,
+                command.identification,
+                command.nacionality,
+                command.gender,
+                command.image,
+            );
             const updated = await this.service.update(rep);
             return Right(updated);
         } catch (error) {

--- a/src/academic/domain/entities/Representative.ts
+++ b/src/academic/domain/entities/Representative.ts
@@ -2,6 +2,14 @@ export class Representative {
     constructor(
         public id: number,
         public firstName: string,
-        public lastName: string
-    ) {}
+        public lastName: string,
+        public phone?: string,
+        public birthDate?: string,
+        public uuidUser?: string,
+        public address?: string,
+        public identification?: string,
+        public nacionality?: string,
+        public gender?: string,
+        public image?: string,
+    ) { }
 }

--- a/src/academic/infrastructure/api/dto/RepresentativeDto.ts
+++ b/src/academic/infrastructure/api/dto/RepresentativeDto.ts
@@ -1,6 +1,14 @@
 export interface RepresentativeInputDto {
     firstName: string;
     lastName: string;
+    phone?: string;
+    birthDate?: string;
+    uuidUser?: string;
+    address?: string;
+    identification?: string;
+    nacionality?: string;
+    gender?: string;
+    image?: string;
 }
 
 export interface RepresentativeOutputDto extends RepresentativeInputDto {

--- a/src/academic/infrastructure/api/mappers/RepresentativeMapper.ts
+++ b/src/academic/infrastructure/api/mappers/RepresentativeMapper.ts
@@ -3,13 +3,33 @@ import { RepresentativeInputDto, RepresentativeOutputDto } from "../dto/Represen
 
 export class RepresentativeMapper {
     static toDomain(raw: RepresentativeOutputDto): Representative {
-        return new Representative(raw.id, raw.firstName, raw.lastName);
+        return new Representative(
+            raw.id,
+            raw.firstName,
+            raw.lastName,
+            raw.phone,
+            raw.birthDate,
+            raw.uuidUser,
+            raw.address,
+            raw.identification,
+            raw.nacionality,
+            raw.gender,
+            raw.image,
+        );
     }
 
     static toDto(entity: Representative): RepresentativeInputDto {
         return {
             firstName: entity.firstName,
-            lastName: entity.lastName
+            lastName: entity.lastName,
+            phone: entity.phone,
+            birthDate: entity.birthDate,
+            uuidUser: entity.uuidUser,
+            address: entity.address,
+            identification: entity.identification,
+            nacionality: entity.nacionality,
+            gender: entity.gender,
+            image: entity.image,
         };
     }
 }

--- a/src/academic/presentation/ui/AcademicHistory/View/AcademicHistoryViewContainer.tsx
+++ b/src/academic/presentation/ui/AcademicHistory/View/AcademicHistoryViewContainer.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { useInjection } from "inversify-react";
+import { AcademicHistory } from "@/academic/domain/entities/AcademicHistory";
+import { GetAcademicHistoryUseCase, GetAcademicHistoryCommand } from "@/academic/application/usecases/academic-history/GetAcademicHistoryUseCase";
+import { AbstractFailure } from "@/academic/domain/entities/failure";
+import { AcademicHistoryViewPresenter } from "./AcademicHistoryViewPresenter";
+
+export function AcademicHistoryViewContainer() {
+  const useCase = useInjection(GetAcademicHistoryUseCase);
+  const [history, setHistory] = useState<AcademicHistory | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSearch = async (studentId: number) => {
+    setLoading(true);
+    setError(null);
+    const result = await useCase.execute(new GetAcademicHistoryCommand(studentId));
+    result.caseOf({
+      Left: (failures: AbstractFailure[]) => setError(failures[0]?.message ?? "Error"),
+      Right: (h: AcademicHistory | undefined) => setHistory(h),
+    });
+    setLoading(false);
+  };
+
+  return (
+    <AcademicHistoryViewPresenter
+      history={history}
+      loading={loading}
+      error={error}
+      onSearch={onSearch}
+    />
+  );
+}
+

--- a/src/academic/presentation/ui/AcademicHistory/View/AcademicHistoryViewPresenter.tsx
+++ b/src/academic/presentation/ui/AcademicHistory/View/AcademicHistoryViewPresenter.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { AcademicHistory } from "@/academic/domain/entities/AcademicHistory";
+
+interface Props {
+  history?: AcademicHistory;
+  loading: boolean;
+  error: string | null;
+  onSearch: (studentId: number) => void;
+}
+
+export function AcademicHistoryViewPresenter({ history, loading, error, onSearch }: Props) {
+  const [studentId, setStudentId] = useState("");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Historial Académico</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex gap-2 mb-4">
+          <Input
+            placeholder="ID de estudiante"
+            value={studentId}
+            onChange={(e) => setStudentId(e.target.value)}
+          />
+          <Button onClick={() => onSearch(Number(studentId))} disabled={loading}>
+            Consultar
+          </Button>
+        </div>
+        {error && <div className="text-destructive mb-4">{error}</div>}
+        {history && (
+          <pre className="bg-muted p-4 rounded text-sm overflow-auto">
+            {JSON.stringify(history, null, 2)}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/academic/presentation/ui/Assessment/Create/AssessmentCreateContainer.tsx
+++ b/src/academic/presentation/ui/Assessment/Create/AssessmentCreateContainer.tsx
@@ -1,0 +1,40 @@
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { ASSESSMENT_SYMBOLS } from "@/academic/domain/symbols/Assessment";
+import { CreateAssessmentCommand, CreateAssessmentUseCase } from "@/academic/application/usecases/assessment/CreateAssessmentUseCase";
+import { toast } from "@/hooks/use-toast";
+import { AssessmentCreatePresenter } from "./AssessmentCreatePresenter";
+
+export const AssessmentCreateContainer = () => {
+  const createUseCase = useInjection<CreateAssessmentUseCase>(ASSESSMENT_SYMBOLS.CREATE_USE_CASE);
+  const { register, handleSubmit, formState: { errors, isSubmitting }, reset } = useForm<CreateAssessmentCommand>();
+
+  const onSubmit = async (data: CreateAssessmentCommand) => {
+    const res = await createUseCase.execute(data);
+    res.ifRight(() => {
+      toast({
+        title: "Evaluación creada",
+        description: "La evaluación ha sido creada correctamente",
+        duration: 5000,
+      });
+      reset();
+    }).ifLeft(failures => {
+      toast({
+        title: "Error",
+        description: failures.map(f => f.message).join(", "),
+        variant: "destructive",
+        duration: 5000,
+      });
+    });
+  };
+
+  return (
+    <AssessmentCreatePresenter
+      onCancel={() => {}}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+      loading={isSubmitting}
+    />
+  );
+};

--- a/src/academic/presentation/ui/Assessment/Create/AssessmentCreatePresenter.tsx
+++ b/src/academic/presentation/ui/Assessment/Create/AssessmentCreatePresenter.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { CreateAssessmentCommand } from "@/academic/application/usecases/assessment/CreateAssessmentUseCase";
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<CreateAssessmentCommand>;
+  errors: FieldErrors<CreateAssessmentCommand>;
+  loading?: boolean;
+}
+
+export const AssessmentCreatePresenter = ({ onCancel, handleSubmit, register, errors, loading }: Props) => (
+  <LayoutForm
+    title="Nueva Evaluación"
+    description="Registrar una evaluación"
+    breadcrumbs={[{ label: "Evaluaciones", href: "/evaluaciones" }, { label: "Nueva" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Registrar Evaluación</CardTitle>
+          <CardDescription>Complete los campos para registrar la evaluación.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="studentId">ID Estudiante *</Label>
+                <Input id="studentId" type="number" {...register("studentId", { valueAsNumber: true, required: "Obligatorio" })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="subjectId">ID Asignatura *</Label>
+                <Input id="subjectId" type="number" {...register("subjectId", { valueAsNumber: true, required: "Obligatorio" })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="score">Calificación *</Label>
+                <Input id="score" type="number" step="0.01" {...register("score", { valueAsNumber: true, required: "Obligatorio" })} />
+              </div>
+            </div>
+            {errors.studentId && <div className="text-destructive text-sm">{errors.studentId.message}</div>}
+            {errors.subjectId && <div className="text-destructive text-sm">{errors.subjectId.message}</div>}
+            {errors.score && <div className="text-destructive text-sm">{errors.score.message}</div>}
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Guardando..." : "Guardar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/Assessment/Edit/AssessmentEditContainer.tsx
+++ b/src/academic/presentation/ui/Assessment/Edit/AssessmentEditContainer.tsx
@@ -1,0 +1,60 @@
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { ASSESSMENT_SYMBOLS } from "@/academic/domain/symbols/Assessment";
+import { UpdateAssessmentCommand, UpdateAssessmentUseCase } from "@/academic/application/usecases/assessment/UpdateAssessmentUseCase";
+import { ListAssessmentsCommand, ListAssessmentsUseCase } from "@/academic/application/usecases/assessment/ListAssessmentsUseCase";
+import { AssessmentEditPresenter } from "./AssessmentEditPresenter";
+import { useParams } from "react-router";
+import { useCallback, useEffect } from "react";
+import { toast } from "@/hooks/use-toast";
+
+export const AssessmentEditContainer = () => {
+  const { id } = useParams();
+  const updateUseCase = useInjection<UpdateAssessmentUseCase>(ASSESSMENT_SYMBOLS.UPDATE_USE_CASE);
+  const listUseCase = useInjection<ListAssessmentsUseCase>(ASSESSMENT_SYMBOLS.LIST_USE_CASE);
+
+  const { handleSubmit, register, setValue, formState: { errors, isSubmitting } } = useForm<UpdateAssessmentCommand & { studentId: number; subjectId: number }>();
+
+  const fetchAssessment = useCallback(async () => {
+    if (!id) return;
+    const res = await listUseCase.execute(new ListAssessmentsCommand());
+    res.ifRight(assessments => {
+      const assessment = assessments?.find(a => a.id === Number(id));
+      if (!assessment) return;
+      setValue("id", assessment.id);
+      setValue("studentId", assessment.studentId);
+      setValue("subjectId", assessment.subjectId);
+      setValue("score", assessment.score);
+    }).ifLeft(failures => {
+      toast({
+        title: "Error",
+        description: failures.map(f => f.message).join(", "),
+        variant: "destructive",
+        duration: 5000,
+      });
+    });
+  }, [id, listUseCase, setValue]);
+
+  useEffect(() => {
+    fetchAssessment();
+  }, [fetchAssessment]);
+
+  const onSubmit = async (data: UpdateAssessmentCommand) => {
+    const res = await updateUseCase.execute(data);
+    res.ifRight(() => {
+      toast({ title: "Evaluación actualizada", description: "La evaluación ha sido actualizada", duration: 5000 });
+    }).ifLeft(failures => {
+      toast({ title: "Error", description: failures.map(f => f.message).join(", "), variant: "destructive", duration: 5000 });
+    });
+  };
+
+  return (
+    <AssessmentEditPresenter
+      onCancel={() => {}}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+      loading={isSubmitting}
+    />
+  );
+};

--- a/src/academic/presentation/ui/Assessment/Edit/AssessmentEditPresenter.tsx
+++ b/src/academic/presentation/ui/Assessment/Edit/AssessmentEditPresenter.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { UpdateAssessmentCommand } from "@/academic/application/usecases/assessment/UpdateAssessmentUseCase";
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<UpdateAssessmentCommand & { studentId: number; subjectId: number }>;
+  errors: FieldErrors<UpdateAssessmentCommand>;
+  loading?: boolean;
+}
+
+export const AssessmentEditPresenter = ({ onCancel, handleSubmit, register, errors, loading }: Props) => (
+  <LayoutForm
+    title="Editar Evaluación"
+    description="Editar la evaluación seleccionada"
+    breadcrumbs={[{ label: "Evaluaciones", href: "/evaluaciones" }, { label: "Editar" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Editar Evaluación</CardTitle>
+          <CardDescription>Modifique los campos necesarios.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input type="hidden" {...register("id", { valueAsNumber: true })} />
+            <div className="grid grid-cols-1 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="studentId">ID Estudiante</Label>
+                <Input id="studentId" type="number" disabled {...register("studentId", { valueAsNumber: true })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="subjectId">ID Asignatura</Label>
+                <Input id="subjectId" type="number" disabled {...register("subjectId", { valueAsNumber: true })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="score">Calificación *</Label>
+                <Input id="score" type="number" step="0.01" {...register("score", { valueAsNumber: true, required: "Obligatorio" })} />
+              </div>
+            </div>
+            {errors.score && <div className="text-destructive text-sm">{errors.score.message}</div>}
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Actualizando..." : "Actualizar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/Assessment/List/AssessmentListContainer.tsx
+++ b/src/academic/presentation/ui/Assessment/List/AssessmentListContainer.tsx
@@ -1,0 +1,37 @@
+import { ListAssessmentsCommand, ListAssessmentsUseCase } from "@/academic/application/usecases/assessment/ListAssessmentsUseCase";
+import { ASSESSMENT_SYMBOLS } from "@/academic/domain/symbols/Assessment";
+import { AssessmentListPresenter } from "./AssessmentListPresenter";
+import { useInjection } from "inversify-react";
+import { useCallback, useEffect, useState } from "react";
+import { Assessment } from "@/academic/domain/entities/Assessment";
+
+export const AssessmentListContainer = () => {
+  const listUseCase = useInjection<ListAssessmentsUseCase>(ASSESSMENT_SYMBOLS.LIST_USE_CASE);
+  const [assessments, setAssessments] = useState<Assessment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const res = await listUseCase.execute(new ListAssessmentsCommand());
+    res.ifRight(data => setAssessments(data ?? [])).ifLeft(failures => setError(failures.map(f => f.message).join(", ")));
+    setLoading(false);
+  }, [listUseCase]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const filtered = assessments.filter(a => a.studentId.toString().includes(searchTerm));
+
+  return (
+    <AssessmentListPresenter
+      assessments={filtered}
+      loading={loading}
+      error={error}
+      searchTerm={searchTerm}
+      onSearchChange={setSearchTerm}
+      onAddAssessment={() => {}}
+    />
+  );
+};

--- a/src/academic/presentation/ui/Assessment/List/AssessmentListPresenter.tsx
+++ b/src/academic/presentation/ui/Assessment/List/AssessmentListPresenter.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Search, Plus } from "lucide-react";
+import { Assessment } from "@/academic/domain/entities/Assessment";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Props {
+  assessments: Assessment[];
+  loading: boolean;
+  error: string | null;
+  searchTerm: string;
+  onSearchChange: (t: string) => void;
+  onAddAssessment: () => void;
+}
+
+export const AssessmentListPresenter = ({ assessments, loading, error, searchTerm, onSearchChange, onAddAssessment }: Props) => (
+  <div className="space-y-6">
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-2xl font-bold">Evaluaciones</CardTitle>
+          <Button onClick={onAddAssessment} className="flex items-center gap-2">
+            <Plus className="h-4 w-4" /> Nueva
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2 mb-6">
+          <Search className="h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Buscar por estudiante" value={searchTerm} onChange={e => onSearchChange(e.target.value)} className="max-w-sm" />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {error && <div className="text-destructive text-center col-span-full">{error}</div>}
+          {assessments.map(a => (
+            <Card key={a.id} className="hover:shadow-md transition-shadow">
+              <CardContent className="p-4">
+                <p className="font-semibold">Estudiante: {a.studentId}</p>
+                <p className="text-sm text-muted-foreground">Asignatura: {a.subjectId}</p>
+                <p className="text-sm">Calificación: {a.score}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        {assessments.length === 0 && !loading && !error && <div className="text-center py-8 text-muted-foreground">No se encontraron evaluaciones</div>}
+      </CardContent>
+    </Card>
+  </div>
+);

--- a/src/academic/presentation/ui/Attendance/Create/AttendanceCreateContainer.tsx
+++ b/src/academic/presentation/ui/Attendance/Create/AttendanceCreateContainer.tsx
@@ -1,0 +1,33 @@
+import { CreateAttendanceCommand, CreateAttendanceUseCase } from "@/academic/application/usecases/attendance/CreateAttendanceUseCase";
+import { ATTENDANCE_SYMBOLS } from "@/academic/domain/symbols/Attendance";
+import { useInjection } from "inversify-react";
+import { useForm } from "react-hook-form";
+import { AttendanceCreatePresenter } from "./AttendanceCreatePresenter";
+import { toast } from "@/hooks/use-toast";
+
+export const AttendanceCreateContainer = () => {
+  const createUseCase = useInjection<CreateAttendanceUseCase>(ATTENDANCE_SYMBOLS.CREATE_USE_CASE);
+  const { register, handleSubmit, control, formState: { errors, isSubmitting } } = useForm<CreateAttendanceCommand>({
+    defaultValues: { studentId: 0, date: "", status: "PRESENT" }
+  });
+
+  const onSubmit = async (data: CreateAttendanceCommand) => {
+    const res = await createUseCase.execute(data);
+    res.ifRight(() => {
+      toast({ title: "Asistencia registrada", description: "La asistencia ha sido creada con éxito", duration: 5000 });
+    }).ifLeft(failures => {
+      toast({ title: "Error", description: failures.map(f=>f.message).join(", "), duration:5000, variant:"destructive" });
+    });
+  };
+
+  return (
+    <AttendanceCreatePresenter
+      onCancel={() => {}}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+      loading={isSubmitting}
+      control={control}
+    />
+  );
+};

--- a/src/academic/presentation/ui/Attendance/Create/AttendanceCreatePresenter.tsx
+++ b/src/academic/presentation/ui/Attendance/Create/AttendanceCreatePresenter.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { CreateAttendanceCommand } from "@/academic/application/usecases/attendance/CreateAttendanceUseCase";
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Controller, FieldErrors, UseFormRegister, Control } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<CreateAttendanceCommand>;
+  errors: FieldErrors<CreateAttendanceCommand>;
+  loading?: boolean;
+  control: Control<CreateAttendanceCommand>;
+}
+
+export const AttendanceCreatePresenter = ({ onCancel, handleSubmit, register, errors, loading, control }: Props) => (
+  <LayoutForm
+    title="Nueva Asistencia"
+    description="Registrar asistencia de un estudiante"
+    breadcrumbs={[{ label: "Asistencias", href: "/asistencias" }, { label: "Nueva Asistencia" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Registrar Asistencia</CardTitle>
+          <CardDescription>Complete los campos para registrar la asistencia.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="studentId">ID Estudiante *</Label>
+                <Input id="studentId" type="number" {...register("studentId", { valueAsNumber: true, required: "Obligatorio" })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="date">Fecha *</Label>
+                <Input id="date" type="date" {...register("date", { required: "Obligatorio" })} />
+              </div>
+              <div className="space-y-2 md:col-span-2">
+                <Label htmlFor="status">Estado *</Label>
+                <Controller
+                  control={control}
+                  name="status"
+                  render={({ field }) => (
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Seleccione estado" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="PRESENT">Presente</SelectItem>
+                        <SelectItem value="ABSENT">Ausente</SelectItem>
+                        <SelectItem value="JUSTIFIED">Justificado</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+              </div>
+            </div>
+            {errors.studentId && <div className="text-destructive text-sm">{errors.studentId.message}</div>}
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Guardando..." : "Guardar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/Attendance/Edit/AttendanceEditContainer.tsx
+++ b/src/academic/presentation/ui/Attendance/Edit/AttendanceEditContainer.tsx
@@ -1,0 +1,59 @@
+import { useForm } from "react-hook-form";
+import { AttendanceEditPresenter } from "./AttendanceEditPresenter";
+import { UpdateAttendanceCommand, UpdateAttendanceUseCase } from "@/academic/application/usecases/attendance/UpdateAttendanceUseCase";
+import { ListAttendanceUseCase, ListAttendanceCommand } from "@/academic/application/usecases/attendance/ListAttendanceUseCase";
+import { useInjection } from "inversify-react";
+import { ATTENDANCE_SYMBOLS } from "@/academic/domain/symbols/Attendance";
+import { useParams } from "react-router";
+import { useCallback, useEffect } from "react";
+import { toast } from "@/hooks/use-toast";
+
+export const AttendanceEditContainer = () => {
+  const { id } = useParams();
+  const updateUseCase = useInjection<UpdateAttendanceUseCase>(ATTENDANCE_SYMBOLS.UPDATE_USE_CASE);
+  const listUseCase = useInjection<ListAttendanceUseCase>(ATTENDANCE_SYMBOLS.LIST_USE_CASE);
+
+  const { handleSubmit, register, watch, setValue, control, formState: { errors, isSubmitting } } = useForm<UpdateAttendanceCommand>();
+  const formData = watch();
+
+  const fetchAttendance = useCallback(async () => {
+    if (!id) return;
+    const res = await listUseCase.execute(new ListAttendanceCommand());
+    res.ifRight(list => {
+      const attendance = list?.find(a => a.id === Number(id));
+      if (attendance) {
+        setValue("id", attendance.id);
+        setValue("status", attendance.status);
+        (setValue as any)("studentId", attendance.studentId);
+        (setValue as any)("date", attendance.date);
+      }
+    }).ifLeft(failures => {
+      toast({ title: "Error", description: failures.map(f=>f.message).join(", "), duration:5000, variant:"destructive" });
+    });
+  }, [id, listUseCase, setValue]);
+
+  useEffect(() => {
+    fetchAttendance();
+  }, [fetchAttendance]);
+
+  const onSubmit = async (data: UpdateAttendanceCommand) => {
+    const res = await updateUseCase.execute(data);
+    res.ifRight(() => {
+      toast({ title: "Asistencia actualizada", description: "La asistencia ha sido actualizada", duration:5000 });
+    }).ifLeft(failures => {
+      toast({ title: "Error", description: failures.map(f=>f.message).join(", "), duration:5000, variant:"destructive" });
+    });
+  };
+
+  return (
+    <AttendanceEditPresenter
+      onCancel={() => {}}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register as any}
+      errors={errors as any}
+      loading={isSubmitting}
+      control={control as any}
+      formData={formData as any}
+    />
+  );
+};

--- a/src/academic/presentation/ui/Attendance/Edit/AttendanceEditPresenter.tsx
+++ b/src/academic/presentation/ui/Attendance/Edit/AttendanceEditPresenter.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Controller, Control, FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<any>;
+  errors: FieldErrors<any>;
+  loading?: boolean;
+  control: Control<any>;
+  formData: any;
+}
+
+export const AttendanceEditPresenter = ({ onCancel, handleSubmit, register, errors, loading, control, formData }: Props) => (
+  <LayoutForm
+    title="Editar Asistencia"
+    description="Actualiza el estado de la asistencia"
+    breadcrumbs={[{ label: "Asistencias", href: "/asistencias" }, { label: "Editar" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Editar Asistencia</CardTitle>
+          <CardDescription>Modifica el estado de la asistencia.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input type="hidden" {...register("id", { valueAsNumber: true })} />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>ID Estudiante</Label>
+                <Input value={formData.studentId || ""} disabled />
+              </div>
+              <div className="space-y-2">
+                <Label>Fecha</Label>
+                <Input value={formData.date || ""} disabled />
+              </div>
+              <div className="space-y-2 md:col-span-2">
+                <Label htmlFor="status">Estado *</Label>
+                <Controller
+                  control={control}
+                  name="status"
+                  render={({ field }) => (
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Seleccione estado" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="PRESENT">Presente</SelectItem>
+                        <SelectItem value="ABSENT">Ausente</SelectItem>
+                        <SelectItem value="JUSTIFIED">Justificado</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+              </div>
+            </div>
+            { (errors as any).status ? (
+              <div className="text-destructive text-sm">{(errors as any).status.message}</div>
+            ) : null }
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Guardando..." : "Guardar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/Attendance/List/AttendanceListContainer.tsx
+++ b/src/academic/presentation/ui/Attendance/List/AttendanceListContainer.tsx
@@ -1,0 +1,39 @@
+import { ListAttendanceUseCase, ListAttendanceCommand } from "@/academic/application/usecases/attendance/ListAttendanceUseCase";
+import { AttendanceListPresenter } from "./AttendanceListPresenter";
+import { useInjection } from "inversify-react";
+import { ATTENDANCE_SYMBOLS } from "@/academic/domain/symbols/Attendance";
+import { useCallback, useEffect, useState } from "react";
+import { Attendance } from "@/academic/domain/entities/Attendance";
+
+export const AttendanceListContainer = () => {
+  const listUseCase = useInjection<ListAttendanceUseCase>(ATTENDANCE_SYMBOLS.LIST_USE_CASE);
+  const [attendances, setAttendances] = useState<Attendance[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const fetchAttendance = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const res = await listUseCase.execute(new ListAttendanceCommand());
+    res.ifRight(data => { setAttendances(data ?? []); }).ifLeft(failures => { setError(failures.map(f=>f.message).join(", ")); });
+    setLoading(false);
+  }, [listUseCase]);
+
+  useEffect(() => { fetchAttendance(); }, [fetchAttendance]);
+
+  const handleSearchChange = (term: string) => setSearchTerm(term);
+
+  const filtered = attendances.filter(a => a.studentId.toString().includes(searchTerm));
+
+  return (
+    <AttendanceListPresenter
+      attendances={filtered}
+      loading={loading}
+      error={error}
+      searchTerm={searchTerm}
+      onSearchChange={handleSearchChange}
+      onAdd={() => {}}
+    />
+  );
+};

--- a/src/academic/presentation/ui/Attendance/List/AttendanceListPresenter.tsx
+++ b/src/academic/presentation/ui/Attendance/List/AttendanceListPresenter.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Search, Plus } from "lucide-react";
+import { Attendance } from "@/academic/domain/entities/Attendance";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Props {
+  attendances: Attendance[];
+  loading: boolean;
+  error: string | null;
+  searchTerm: string;
+  onSearchChange: (term: string) => void;
+  onAdd: () => void;
+}
+
+export const AttendanceListPresenter = ({ attendances, loading, error, searchTerm, onSearchChange, onAdd }: Props) => (
+  <div className="space-y-6">
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-2xl font-bold">Asistencias</CardTitle>
+          <Button onClick={onAdd} className="flex items-center gap-2">
+            <Plus className="h-4 w-4" /> Registrar
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2 mb-6">
+          <Search className="h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Buscar por ID de estudiante" value={searchTerm} onChange={e=>onSearchChange(e.target.value)} className="max-w-sm" />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {error && <div className="text-destructive text-center col-span-full">{error}</div>}
+          {attendances.map(a => (
+            <Card key={a.id} className="hover:shadow-md transition-shadow">
+              <CardContent className="p-4">
+                <div className="text-sm font-medium">Estudiante: {a.studentId}</div>
+                <div className="text-xs text-muted-foreground">Fecha: {a.date}</div>
+                <div className="text-xs">Estado: {a.status}</div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        {attendances.length === 0 && !loading && !error && (
+          <div className="text-center py-8 text-muted-foreground">No se encontraron asistencias</div>
+        )}
+      </CardContent>
+    </Card>
+  </div>
+);

--- a/src/academic/presentation/ui/BehaviorReport/Create/BehaviorReportCreateContainer.tsx
+++ b/src/academic/presentation/ui/BehaviorReport/Create/BehaviorReportCreateContainer.tsx
@@ -1,0 +1,50 @@
+import { CreateBehaviorReportCommand, CreateBehaviorReportUseCase } from "@/academic/application/usecases/behavior-report/CreateBehaviorReportUseCase";
+import { BEHAVIOR_REPORT_SYMBOLS } from "@/academic/domain/symbols/BehaviorReport";
+import { BehaviorReportCreatePresenter } from "./BehaviorReportCreatePresenter";
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { toast } from "@/hooks/use-toast";
+
+export const BehaviorReportCreateContainer = () => {
+  const createUseCase = useInjection<CreateBehaviorReportUseCase>(BEHAVIOR_REPORT_SYMBOLS.CREATE_USE_CASE);
+
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<CreateBehaviorReportCommand>({
+    defaultValues: {
+      studentId: 0,
+      description: "",
+    },
+  });
+
+  const onSubmit = async (data: CreateBehaviorReportCommand) => {
+    const res = await createUseCase.execute(data);
+    res.ifRight((report) => {
+      toast({
+        title: "Reporte creado",
+        description: `Se registró el reporte para el estudiante ${report?.studentId}.`,
+        duration: 5000,
+      });
+      onCancel();
+    }).ifLeft((failures) => {
+      toast({
+        title: "Error",
+        description: "Error al crear el reporte: " + failures.map(f => f.message).join(", "),
+        variant: "destructive",
+        duration: 5000,
+      });
+    });
+  };
+
+  const onCancel = () => {
+    // Implement navigation or state reset if needed
+  };
+
+  return (
+    <BehaviorReportCreatePresenter
+      onCancel={onCancel}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+      loading={isSubmitting}
+    />
+  );
+};

--- a/src/academic/presentation/ui/BehaviorReport/Create/BehaviorReportCreatePresenter.tsx
+++ b/src/academic/presentation/ui/BehaviorReport/Create/BehaviorReportCreatePresenter.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { CreateBehaviorReportCommand } from "@/academic/application/usecases/behavior-report/CreateBehaviorReportUseCase";
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<CreateBehaviorReportCommand>;
+  errors: FieldErrors<CreateBehaviorReportCommand>;
+  loading?: boolean;
+}
+
+export const BehaviorReportCreatePresenter = ({ onCancel, handleSubmit, register, errors, loading }: Props) => (
+  <LayoutForm
+    title="Nuevo Reporte de Conducta"
+    description="Registrar un nuevo reporte de conducta"
+    breadcrumbs={[{ label: "Reportes de Conducta", href: "/reportes-conducta" }, { label: "Nuevo Reporte" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Registrar Reporte</CardTitle>
+          <CardDescription>Complete los campos para registrar el reporte.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="studentId">ID Estudiante *</Label>
+                <Input id="studentId" type="number" {...register("studentId", { valueAsNumber: true, required: "Obligatorio" })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="description">Descripción *</Label>
+                <Textarea id="description" {...register("description", { required: "Obligatorio" })} />
+              </div>
+            </div>
+            {errors.studentId && <div className="text-destructive text-sm">{errors.studentId.message}</div>}
+            {errors.description && <div className="text-destructive text-sm">{errors.description.message}</div>}
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Guardando..." : "Guardar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/BehaviorReport/Edit/BehaviorReportEditContainer.tsx
+++ b/src/academic/presentation/ui/BehaviorReport/Edit/BehaviorReportEditContainer.tsx
@@ -1,0 +1,69 @@
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { BEHAVIOR_REPORT_SYMBOLS } from "@/academic/domain/symbols/BehaviorReport";
+import { UpdateBehaviorReportCommand, UpdateBehaviorReportUseCase } from "@/academic/application/usecases/behavior-report/UpdateBehaviorReportUseCase";
+import { ListBehaviorReportsCommand, ListBehaviorReportsUseCase } from "@/academic/application/usecases/behavior-report/ListBehaviorReportsUseCase";
+import { BehaviorReportEditPresenter } from "./BehaviorReportEditPresenter";
+import { useParams } from "react-router";
+import { useCallback, useEffect } from "react";
+import { toast } from "@/hooks/use-toast";
+
+export const BehaviorReportEditContainer = () => {
+  const { id } = useParams();
+
+  const updateUseCase = useInjection<UpdateBehaviorReportUseCase>(BEHAVIOR_REPORT_SYMBOLS.UPDATE_USE_CASE);
+  const listUseCase = useInjection<ListBehaviorReportsUseCase>(BEHAVIOR_REPORT_SYMBOLS.LIST_USE_CASE);
+
+  const { handleSubmit, register, setValue, formState: { errors, isSubmitting } } = useForm<UpdateBehaviorReportCommand & { studentId: number }>();
+
+  const fetchReport = useCallback(async () => {
+    if (!id) return;
+    const res = await listUseCase.execute(new ListBehaviorReportsCommand());
+    res.ifRight((reports) => {
+      const report = reports?.find(r => r.id === Number(id));
+      if (!report) return;
+      setValue("id", report.id);
+      setValue("description", report.description);
+      setValue("studentId", report.studentId);
+    }).ifLeft((failures) => {
+      toast({
+        title: "Error",
+        description: "Error al obtener el reporte: " + failures.map(f => f.message).join(", "),
+        variant: "destructive",
+        duration: 5000,
+      });
+    });
+  }, [id, listUseCase, setValue]);
+
+  useEffect(() => {
+    fetchReport();
+  }, [fetchReport]);
+
+  const onSubmit = async (data: UpdateBehaviorReportCommand) => {
+    const res = await updateUseCase.execute(data);
+    res.ifRight(() => {
+      toast({
+        title: "Reporte actualizado",
+        description: `El reporte ha sido actualizado con éxito.`,
+        duration: 5000,
+      });
+    }).ifLeft((failures) => {
+      toast({
+        title: "Error",
+        description: "Error al actualizar el reporte: " + failures.map(f => f.message).join(", "),
+        variant: "destructive",
+        duration: 5000,
+      });
+    });
+  };
+
+  return (
+    <BehaviorReportEditPresenter
+      onCancel={() => { }}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+      loading={isSubmitting}
+    />
+  );
+};

--- a/src/academic/presentation/ui/BehaviorReport/Edit/BehaviorReportEditPresenter.tsx
+++ b/src/academic/presentation/ui/BehaviorReport/Edit/BehaviorReportEditPresenter.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { UpdateBehaviorReportCommand } from "@/academic/application/usecases/behavior-report/UpdateBehaviorReportUseCase";
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<UpdateBehaviorReportCommand & { studentId: number }>;
+  errors: FieldErrors<UpdateBehaviorReportCommand & { studentId: number }>;
+  loading?: boolean;
+}
+
+export const BehaviorReportEditPresenter = ({ onCancel, handleSubmit, register, errors, loading }: Props) => (
+  <LayoutForm
+    title="Editar Reporte de Conducta"
+    description="Modificar un reporte de conducta"
+    breadcrumbs={[{ label: "Reportes de Conducta", href: "/reportes-conducta" }, { label: "Editar Reporte" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Editar Reporte</CardTitle>
+          <CardDescription>Actualiza la información del reporte.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input type="hidden" {...register("id", { valueAsNumber: true })} />
+            <div className="grid grid-cols-1 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="studentId">ID Estudiante</Label>
+                <Input id="studentId" type="number" disabled {...register("studentId", { valueAsNumber: true })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="description">Descripción *</Label>
+                <Textarea id="description" {...register("description", { required: "Obligatorio" })} />
+              </div>
+            </div>
+            {errors.description && <div className="text-destructive text-sm">{errors.description.message}</div>}
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Guardando..." : "Guardar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/BehaviorReport/List/BehaviorReportListContainer.tsx
+++ b/src/academic/presentation/ui/BehaviorReport/List/BehaviorReportListContainer.tsx
@@ -1,0 +1,50 @@
+import { ListBehaviorReportsCommand, ListBehaviorReportsUseCase } from "@/academic/application/usecases/behavior-report/ListBehaviorReportsUseCase";
+import { BehaviorReport } from "@/academic/domain/entities/BehaviorReport";
+import { BEHAVIOR_REPORT_SYMBOLS } from "@/academic/domain/symbols/BehaviorReport";
+import { useInjection } from "inversify-react";
+import { useCallback, useEffect, useState } from "react";
+import { BehaviorReportListPresenter } from "./BehaviorReportListPresenter";
+
+export const BehaviorReportListContainer = () => {
+  const listUseCase = useInjection<ListBehaviorReportsUseCase>(BEHAVIOR_REPORT_SYMBOLS.LIST_USE_CASE);
+
+  const [reports, setReports] = useState<BehaviorReport[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const fetchReports = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const res = await listUseCase.execute(new ListBehaviorReportsCommand());
+    res.ifRight(data => {
+      setReports(data ?? []);
+    }).ifLeft(failures => {
+      setError(failures.map(f => f.message).join(", "));
+    });
+    setLoading(false);
+  }, [listUseCase]);
+
+  useEffect(() => {
+    fetchReports();
+  }, [fetchReports]);
+
+  const handleSearchChange = (term: string) => {
+    setSearchTerm(term);
+  };
+
+  const filteredReports = reports.filter(r =>
+    r.description.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  return (
+    <BehaviorReportListPresenter
+      reports={filteredReports}
+      loading={loading}
+      error={error}
+      onAddReport={() => { }}
+      searchTerm={searchTerm}
+      onSearchChange={handleSearchChange}
+    />
+  );
+};

--- a/src/academic/presentation/ui/BehaviorReport/List/BehaviorReportListPresenter.tsx
+++ b/src/academic/presentation/ui/BehaviorReport/List/BehaviorReportListPresenter.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Search, Plus } from "lucide-react";
+import { BehaviorReport } from "@/academic/domain/entities/BehaviorReport";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Props {
+  reports: BehaviorReport[];
+  loading: boolean;
+  error: string | null;
+  searchTerm: string;
+  onSearchChange: (term: string) => void;
+  onAddReport: () => void;
+}
+
+export function BehaviorReportListPresenter({
+  reports,
+  loading,
+  error,
+  searchTerm,
+  onSearchChange,
+  onAddReport,
+}: Props) {
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-2xl font-bold">Reportes de Conducta</CardTitle>
+            <Button onClick={onAddReport} className="flex items-center gap-2">
+              <Plus className="h-4 w-4" />
+              Agregar Reporte
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-2 mb-6">
+            <Search className="h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Buscar reportes..."
+              value={searchTerm}
+              onChange={(e) => onSearchChange(e.target.value)}
+              className="max-w-sm"
+            />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {loading && <Skeleton className="h-24 w-full col-span-full" />}
+            {error && (
+              <div className="text-destructive text-center col-span-full">{error}</div>
+            )}
+            {reports.map((report) => (
+              <Card key={report.id} className="hover:shadow-md transition-shadow">
+                <CardContent className="p-4">
+                  <p className="font-semibold text-sm">Estudiante: {report.studentId}</p>
+                  <p className="text-xs text-muted-foreground mt-2 line-clamp-3">
+                    {report.description}
+                  </p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          {reports.length === 0 && !loading && !error && (
+            <div className="text-center py-8 text-muted-foreground">
+              No se encontraron reportes
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/academic/presentation/ui/Enrollment/Create/EnrollmentCreateContainer.tsx
+++ b/src/academic/presentation/ui/Enrollment/Create/EnrollmentCreateContainer.tsx
@@ -1,0 +1,32 @@
+import { CreateEnrollmentCommand, CreateEnrollmentUseCase } from "@/academic/application/usecases/enrollment/CreateEnrollmentUseCase";
+import { ENROLLMENT_SYMBOLS } from "@/academic/domain/symbols/Enrollment";
+import { useInjection } from "inversify-react";
+import { useForm } from "react-hook-form";
+import { EnrollmentCreatePresenter } from "./EnrollmentCreatePresenter";
+import { toast } from "@/hooks/use-toast";
+
+export const EnrollmentCreateContainer = () => {
+  const createUseCase = useInjection<CreateEnrollmentUseCase>(ENROLLMENT_SYMBOLS.CREATE_USE_CASE);
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<CreateEnrollmentCommand>({
+    defaultValues: { studentId: 0, courseId: "" }
+  });
+
+  const onSubmit = async (data: CreateEnrollmentCommand) => {
+    const res = await createUseCase.execute(data);
+    res.ifRight(() => {
+      toast({ title: "Matrícula creada", description: "La matrícula ha sido registrada", duration:5000 });
+    }).ifLeft(failures => {
+      toast({ title: "Error", description: failures.map(f=>f.message).join(", "), duration:5000, variant:"destructive" });
+    });
+  };
+
+  return (
+    <EnrollmentCreatePresenter
+      onCancel={() => {}}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+      loading={isSubmitting}
+    />
+  );
+};

--- a/src/academic/presentation/ui/Enrollment/Create/EnrollmentCreatePresenter.tsx
+++ b/src/academic/presentation/ui/Enrollment/Create/EnrollmentCreatePresenter.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { CreateEnrollmentCommand } from "@/academic/application/usecases/enrollment/CreateEnrollmentUseCase";
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<CreateEnrollmentCommand>;
+  errors: FieldErrors<CreateEnrollmentCommand>;
+  loading?: boolean;
+}
+
+export const EnrollmentCreatePresenter = ({ onCancel, handleSubmit, register, errors, loading }: Props) => (
+  <LayoutForm
+    title="Nueva Matrícula"
+    description="Registrar matrícula de un estudiante"
+    breadcrumbs={[{ label: "Matrículas", href: "/matriculas" }, { label: "Nueva Matrícula" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Registrar Matrícula</CardTitle>
+          <CardDescription>Complete los campos para registrar una matrícula.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="studentId">ID Estudiante *</Label>
+                <Input id="studentId" type="number" {...register("studentId", { valueAsNumber: true, required: "Obligatorio" })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="courseId">ID Curso *</Label>
+                <Input id="courseId" {...register("courseId", { required: "Obligatorio" })} />
+              </div>
+            </div>
+            {errors.courseId ? (
+              <div className="text-destructive text-sm">{errors.courseId.message}</div>
+            ) : null}
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Guardando..." : "Guardar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/Enrollment/Edit/EnrollmentEditContainer.tsx
+++ b/src/academic/presentation/ui/Enrollment/Edit/EnrollmentEditContainer.tsx
@@ -1,0 +1,52 @@
+import { useForm } from "react-hook-form";
+import { EnrollmentEditPresenter } from "./EnrollmentEditPresenter";
+import { UpdateEnrollmentCommand, UpdateEnrollmentUseCase } from "@/academic/application/usecases/enrollment/UpdateEnrollmentUseCase";
+import { ListEnrollmentsUseCase, ListEnrollmentsCommand } from "@/academic/application/usecases/enrollment/ListEnrollmentsUseCase";
+import { useInjection } from "inversify-react";
+import { ENROLLMENT_SYMBOLS } from "@/academic/domain/symbols/Enrollment";
+import { useParams } from "react-router";
+import { useCallback, useEffect } from "react";
+import { toast } from "@/hooks/use-toast";
+
+export const EnrollmentEditContainer = () => {
+  const { id } = useParams();
+  const updateUseCase = useInjection<UpdateEnrollmentUseCase>(ENROLLMENT_SYMBOLS.UPDATE_USE_CASE);
+  const listUseCase = useInjection<ListEnrollmentsUseCase>(ENROLLMENT_SYMBOLS.LIST_USE_CASE);
+
+  const { handleSubmit, register, watch, setValue, formState: { errors, isSubmitting } } = useForm<UpdateEnrollmentCommand>();
+  const formData = watch();
+
+  const fetchEnrollment = useCallback(async () => {
+    if (!id) return;
+    const res = await listUseCase.execute(new ListEnrollmentsCommand());
+    res.ifRight(list => {
+      const enrollment = list?.find(e => e.id === Number(id));
+      if (enrollment) {
+        setValue("id", enrollment.id);
+        setValue("courseId", enrollment.courseId);
+        (setValue as any)("studentId", enrollment.studentId);
+      }
+    }).ifLeft(failures => {
+      toast({ title: "Error", description: failures.map(f=>f.message).join(", "), duration:5000, variant:"destructive" });
+    });
+  }, [id, listUseCase, setValue]);
+
+  useEffect(() => { fetchEnrollment(); }, [fetchEnrollment]);
+
+  const onSubmit = async (data: UpdateEnrollmentCommand) => {
+    const res = await updateUseCase.execute(data);
+    res.ifRight(() => { toast({ title: "Matrícula actualizada", description: "La matrícula ha sido actualizada", duration:5000 }); });
+    res.ifLeft(failures => { toast({ title: "Error", description: failures.map(f=>f.message).join(", "), duration:5000, variant:"destructive" }); });
+  };
+
+  return (
+    <EnrollmentEditPresenter
+      onCancel={() => {}}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register as any}
+      errors={errors as any}
+      loading={isSubmitting}
+      formData={formData as any}
+    />
+  );
+};

--- a/src/academic/presentation/ui/Enrollment/Edit/EnrollmentEditPresenter.tsx
+++ b/src/academic/presentation/ui/Enrollment/Edit/EnrollmentEditPresenter.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<any>;
+  errors: FieldErrors<any>;
+  loading?: boolean;
+  formData: any;
+}
+
+export const EnrollmentEditPresenter = ({ onCancel, handleSubmit, register, errors, loading, formData }: Props) => (
+  <LayoutForm
+    title="Editar Matrícula"
+    description="Actualiza los datos de la matrícula"
+    breadcrumbs={[{ label: "Matrículas", href: "/matriculas" }, { label: "Editar" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Editar Matrícula</CardTitle>
+          <CardDescription>Modifica el curso de la matrícula.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input type="hidden" {...register("id", { valueAsNumber: true })} />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>ID Estudiante</Label>
+                <Input value={formData.studentId || ""} disabled />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="courseId">ID Curso *</Label>
+                <Input id="courseId" {...register("courseId", { required: "Obligatorio" })} />
+              </div>
+            </div>
+              {(errors as any).courseId ? (
+                <div className="text-destructive text-sm">{(errors as any).courseId.message}</div>
+              ) : null}
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Guardando..." : "Guardar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/Enrollment/List/EnrollmentListContainer.tsx
+++ b/src/academic/presentation/ui/Enrollment/List/EnrollmentListContainer.tsx
@@ -1,0 +1,39 @@
+import { ListEnrollmentsUseCase, ListEnrollmentsCommand } from "@/academic/application/usecases/enrollment/ListEnrollmentsUseCase";
+import { EnrollmentListPresenter } from "./EnrollmentListPresenter";
+import { useInjection } from "inversify-react";
+import { ENROLLMENT_SYMBOLS } from "@/academic/domain/symbols/Enrollment";
+import { useCallback, useEffect, useState } from "react";
+import { Enrollment } from "@/academic/domain/entities/Enrollment";
+
+export const EnrollmentListContainer = () => {
+  const listUseCase = useInjection<ListEnrollmentsUseCase>(ENROLLMENT_SYMBOLS.LIST_USE_CASE);
+  const [enrollments, setEnrollments] = useState<Enrollment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const fetchEnrollments = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const res = await listUseCase.execute(new ListEnrollmentsCommand());
+    res.ifRight(data => { setEnrollments(data ?? []); }).ifLeft(failures => { setError(failures.map(f=>f.message).join(", ")); });
+    setLoading(false);
+  }, [listUseCase]);
+
+  useEffect(() => { fetchEnrollments(); }, [fetchEnrollments]);
+
+  const handleSearchChange = (term: string) => setSearchTerm(term);
+
+  const filtered = enrollments.filter(e => e.courseId.toLowerCase().includes(searchTerm.toLowerCase()));
+
+  return (
+    <EnrollmentListPresenter
+      enrollments={filtered}
+      loading={loading}
+      error={error}
+      searchTerm={searchTerm}
+      onSearchChange={handleSearchChange}
+      onAdd={() => {}}
+    />
+  );
+};

--- a/src/academic/presentation/ui/Enrollment/List/EnrollmentListPresenter.tsx
+++ b/src/academic/presentation/ui/Enrollment/List/EnrollmentListPresenter.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Search, Plus } from "lucide-react";
+import { Enrollment } from "@/academic/domain/entities/Enrollment";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Props {
+  enrollments: Enrollment[];
+  loading: boolean;
+  error: string | null;
+  searchTerm: string;
+  onSearchChange: (term: string) => void;
+  onAdd: () => void;
+}
+
+export const EnrollmentListPresenter = ({ enrollments, loading, error, searchTerm, onSearchChange, onAdd }: Props) => (
+  <div className="space-y-6">
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-2xl font-bold">Matrículas</CardTitle>
+          <Button onClick={onAdd} className="flex items-center gap-2">
+            <Plus className="h-4 w-4" /> Registrar
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2 mb-6">
+          <Search className="h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Buscar por curso" value={searchTerm} onChange={e=>onSearchChange(e.target.value)} className="max-w-sm" />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {error && <div className="text-destructive text-center col-span-full">{error}</div>}
+          {enrollments.map(e => (
+            <Card key={e.id} className="hover:shadow-md transition-shadow">
+              <CardContent className="p-4">
+                <div className="text-sm font-medium">Estudiante: {e.studentId}</div>
+                <div className="text-xs">Curso: {e.courseId}</div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        {enrollments.length === 0 && !loading && !error && (
+          <div className="text-center py-8 text-muted-foreground">No se encontraron matrículas</div>
+        )}
+      </CardContent>
+    </Card>
+  </div>
+);

--- a/src/academic/presentation/ui/Exports/ReportCard/ExportReportCardContainer.tsx
+++ b/src/academic/presentation/ui/Exports/ReportCard/ExportReportCardContainer.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import { useInjection } from "inversify-react";
+import { ExportReportCardUseCase, ExportReportCardCommand } from "@/academic/application/usecases/exports/ExportReportCardUseCase";
+import { ExportReportCardPresenter } from "./ExportReportCardPresenter";
+import { AbstractFailure } from "@/academic/domain/entities/failure";
+
+export function ExportReportCardContainer() {
+  const useCase = useInjection(ExportReportCardUseCase);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onExport = async (studentId: number, academicYearId: string, format: string) => {
+    setLoading(true);
+    setError(null);
+    const res = await useCase.execute(new ExportReportCardCommand(studentId, academicYearId, format));
+    res.caseOf({
+      Left: (f: AbstractFailure[]) => setError(f[0]?.message ?? "Error"),
+      Right: (blob: Blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `boleta.${format}`;
+        a.click();
+        URL.revokeObjectURL(url);
+      },
+    });
+    setLoading(false);
+  };
+
+  return <ExportReportCardPresenter loading={loading} error={error} onExport={onExport} />;
+}
+

--- a/src/academic/presentation/ui/Exports/ReportCard/ExportReportCardPresenter.tsx
+++ b/src/academic/presentation/ui/Exports/ReportCard/ExportReportCardPresenter.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  loading: boolean;
+  error: string | null;
+  onExport: (studentId: number, academicYearId: string, format: string) => void;
+}
+
+export function ExportReportCardPresenter({ loading, error, onExport }: Props) {
+  const [studentId, setStudentId] = useState("");
+  const [year, setYear] = useState("");
+  const [format, setFormat] = useState("pdf");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Exportar Boleta</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col md:flex-row gap-2 mb-4">
+          <Input placeholder="ID estudiante" value={studentId} onChange={(e) => setStudentId(e.target.value)} />
+          <Input placeholder="Año académico" value={year} onChange={(e) => setYear(e.target.value)} />
+          <Input placeholder="Formato" value={format} onChange={(e) => setFormat(e.target.value)} />
+          <Button onClick={() => onExport(Number(studentId), year, format)} disabled={loading}>
+            Exportar
+          </Button>
+        </div>
+        {error && <div className="text-destructive">{error}</div>}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/academic/presentation/ui/Exports/Statistics/ExportStatisticsContainer.tsx
+++ b/src/academic/presentation/ui/Exports/Statistics/ExportStatisticsContainer.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import { useInjection } from "inversify-react";
+import { ExportStatisticsUseCase, ExportStatisticsCommand } from "@/academic/application/usecases/exports/ExportStatisticsUseCase";
+import { ExportStatisticsPresenter } from "./ExportStatisticsPresenter";
+import { AbstractFailure } from "@/academic/domain/entities/failure";
+
+export function ExportStatisticsContainer() {
+  const useCase = useInjection(ExportStatisticsUseCase);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onExport = async (courseId: string, academicYearId: string, format: string) => {
+    setLoading(true);
+    setError(null);
+    const res = await useCase.execute(new ExportStatisticsCommand(courseId, academicYearId, format));
+    res.caseOf({
+      Left: (f: AbstractFailure[]) => setError(f[0]?.message ?? "Error"),
+      Right: (blob: Blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `estadisticas.${format}`;
+        a.click();
+        URL.revokeObjectURL(url);
+      },
+    });
+    setLoading(false);
+  };
+
+  return <ExportStatisticsPresenter loading={loading} error={error} onExport={onExport} />;
+}
+

--- a/src/academic/presentation/ui/Exports/Statistics/ExportStatisticsPresenter.tsx
+++ b/src/academic/presentation/ui/Exports/Statistics/ExportStatisticsPresenter.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  loading: boolean;
+  error: string | null;
+  onExport: (courseId: string, academicYearId: string, format: string) => void;
+}
+
+export function ExportStatisticsPresenter({ loading, error, onExport }: Props) {
+  const [course, setCourse] = useState("");
+  const [year, setYear] = useState("");
+  const [format, setFormat] = useState("pdf");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Exportar Estadísticas</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col md:flex-row gap-2 mb-4">
+          <Input placeholder="Curso" value={course} onChange={(e) => setCourse(e.target.value)} />
+          <Input placeholder="Año académico" value={year} onChange={(e) => setYear(e.target.value)} />
+          <Input placeholder="Formato" value={format} onChange={(e) => setFormat(e.target.value)} />
+          <Button onClick={() => onExport(course, year, format)} disabled={loading}>Exportar</Button>
+        </div>
+        {error && <div className="text-destructive">{error}</div>}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/academic/presentation/ui/Grading/FinalGradeContainer.tsx
+++ b/src/academic/presentation/ui/Grading/FinalGradeContainer.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { useInjection } from "inversify-react";
+import { FinalGrade } from "@/academic/domain/entities/FinalGrade";
+import { GetFinalGradeUseCase, GetFinalGradeCommand } from "@/academic/application/usecases/grading/GetFinalGradeUseCase";
+import { AbstractFailure } from "@/academic/domain/entities/failure";
+import { FinalGradePresenter } from "./FinalGradePresenter";
+
+export function FinalGradeContainer() {
+  const useCase = useInjection(GetFinalGradeUseCase);
+  const [grade, setGrade] = useState<FinalGrade | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSearch = async (studentId: number, subjectId: number, year: string) => {
+    setLoading(true);
+    setError(null);
+    const res = await useCase.execute(new GetFinalGradeCommand(studentId, subjectId, year));
+    res.caseOf({
+      Left: (f: AbstractFailure[]) => setError(f[0]?.message ?? "Error"),
+      Right: (g: FinalGrade | undefined) => setGrade(g),
+    });
+    setLoading(false);
+  };
+
+  return (
+    <FinalGradePresenter
+      grade={grade}
+      loading={loading}
+      error={error}
+      onSearch={onSearch}
+    />
+  );
+}
+

--- a/src/academic/presentation/ui/Grading/FinalGradePresenter.tsx
+++ b/src/academic/presentation/ui/Grading/FinalGradePresenter.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { FinalGrade } from "@/academic/domain/entities/FinalGrade";
+
+interface Props {
+  grade?: FinalGrade;
+  loading: boolean;
+  error: string | null;
+  onSearch: (studentId: number, subjectId: number, year: string) => void;
+}
+
+export function FinalGradePresenter({ grade, loading, error, onSearch }: Props) {
+  const [studentId, setStudentId] = useState("");
+  const [subjectId, setSubjectId] = useState("");
+  const [year, setYear] = useState("");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Calificación Final</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col md:flex-row gap-2 mb-4">
+          <Input placeholder="ID estudiante" value={studentId} onChange={(e) => setStudentId(e.target.value)} />
+          <Input placeholder="ID materia" value={subjectId} onChange={(e) => setSubjectId(e.target.value)} />
+          <Input placeholder="Año escolar" value={year} onChange={(e) => setYear(e.target.value)} />
+          <Button onClick={() => onSearch(Number(studentId), Number(subjectId), year)} disabled={loading}>Consultar</Button>
+        </div>
+        {error && <div className="text-destructive mb-4">{error}</div>}
+        {grade && (
+          <pre className="bg-muted p-4 rounded text-sm overflow-auto">
+            {JSON.stringify(grade, null, 2)}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/academic/presentation/ui/Meeting/Create/MeetingCreateContainer.tsx
+++ b/src/academic/presentation/ui/Meeting/Create/MeetingCreateContainer.tsx
@@ -1,0 +1,31 @@
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { MEETING_SYMBOLS } from "@/academic/domain/symbols/Meeting";
+import { CreateMeetingCommand, CreateMeetingUseCase } from "@/academic/application/usecases/meeting/CreateMeetingUseCase";
+import { toast } from "@/hooks/use-toast";
+import { MeetingCreatePresenter } from "./MeetingCreatePresenter";
+
+export const MeetingCreateContainer = () => {
+  const createUseCase = useInjection<CreateMeetingUseCase>(MEETING_SYMBOLS.CREATE_USE_CASE);
+  const { register, handleSubmit, formState: { errors, isSubmitting }, reset } = useForm<CreateMeetingCommand>();
+
+  const onSubmit = async (data: CreateMeetingCommand) => {
+    const res = await createUseCase.execute(data);
+    res.ifRight(() => {
+      toast({ title: "Reunión creada", description: "La reunión ha sido registrada", duration: 5000 });
+      reset();
+    }).ifLeft(failures => {
+      toast({ title: "Error", description: failures.map(f => f.message).join(", "), variant: "destructive", duration: 5000 });
+    });
+  };
+
+  return (
+    <MeetingCreatePresenter
+      onCancel={() => {}}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+      loading={isSubmitting}
+    />
+  );
+};

--- a/src/academic/presentation/ui/Meeting/Create/MeetingCreatePresenter.tsx
+++ b/src/academic/presentation/ui/Meeting/Create/MeetingCreatePresenter.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { CreateMeetingCommand } from "@/academic/application/usecases/meeting/CreateMeetingUseCase";
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<CreateMeetingCommand>;
+  errors: FieldErrors<CreateMeetingCommand>;
+  loading?: boolean;
+}
+
+export const MeetingCreatePresenter = ({ onCancel, handleSubmit, register, errors, loading }: Props) => (
+  <LayoutForm
+    title="Nueva Reunión"
+    description="Registrar una nueva reunión"
+    breadcrumbs={[{ label: "Reuniones", href: "/reuniones" }, { label: "Nueva" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Registrar Reunión</CardTitle>
+          <CardDescription>Complete los campos para registrar la reunión.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="topic">Tema *</Label>
+                <Input id="topic" {...register("topic", { required: "Obligatorio" })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="date">Fecha *</Label>
+                <Input id="date" type="date" {...register("date", { required: "Obligatorio" })} />
+              </div>
+            </div>
+            {errors.topic && <div className="text-destructive text-sm">{errors.topic.message}</div>}
+            {errors.date && <div className="text-destructive text-sm">{errors.date.message}</div>}
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Guardando..." : "Guardar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/Meeting/Edit/MeetingEditContainer.tsx
+++ b/src/academic/presentation/ui/Meeting/Edit/MeetingEditContainer.tsx
@@ -1,0 +1,52 @@
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { MEETING_SYMBOLS } from "@/academic/domain/symbols/Meeting";
+import { UpdateMeetingCommand, UpdateMeetingUseCase } from "@/academic/application/usecases/meeting/UpdateMeetingUseCase";
+import { ListMeetingsCommand, ListMeetingsUseCase } from "@/academic/application/usecases/meeting/ListMeetingsUseCase";
+import { MeetingEditPresenter } from "./MeetingEditPresenter";
+import { useParams } from "react-router";
+import { useCallback, useEffect } from "react";
+import { toast } from "@/hooks/use-toast";
+
+export const MeetingEditContainer = () => {
+  const { id } = useParams();
+  const updateUseCase = useInjection<UpdateMeetingUseCase>(MEETING_SYMBOLS.UPDATE_USE_CASE);
+  const listUseCase = useInjection<ListMeetingsUseCase>(MEETING_SYMBOLS.LIST_USE_CASE);
+
+  const { handleSubmit, register, setValue, formState: { errors, isSubmitting } } = useForm<UpdateMeetingCommand & { date: string }>();
+
+  const fetchMeeting = useCallback(async () => {
+    if (!id) return;
+    const res = await listUseCase.execute(new ListMeetingsCommand());
+    res.ifRight(meetings => {
+      const meeting = meetings?.find(m => m.id === Number(id));
+      if (!meeting) return;
+      setValue("id", meeting.id);
+      setValue("topic", meeting.topic);
+      setValue("date", meeting.date);
+    }).ifLeft(failures => {
+      toast({ title: "Error", description: failures.map(f => f.message).join(", "), variant: "destructive", duration: 5000 });
+    });
+  }, [id, listUseCase, setValue]);
+
+  useEffect(() => { fetchMeeting(); }, [fetchMeeting]);
+
+  const onSubmit = async (data: UpdateMeetingCommand & { date: string }) => {
+    const res = await updateUseCase.execute(new UpdateMeetingCommand(data.id, data.topic));
+    res.ifRight(() => {
+      toast({ title: "Reunión actualizada", description: "La reunión ha sido actualizada", duration: 5000 });
+    }).ifLeft(failures => {
+      toast({ title: "Error", description: failures.map(f => f.message).join(", "), variant: "destructive", duration: 5000 });
+    });
+  };
+
+  return (
+    <MeetingEditPresenter
+      onCancel={() => {}}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+      loading={isSubmitting}
+    />
+  );
+};

--- a/src/academic/presentation/ui/Meeting/Edit/MeetingEditPresenter.tsx
+++ b/src/academic/presentation/ui/Meeting/Edit/MeetingEditPresenter.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { UpdateMeetingCommand } from "@/academic/application/usecases/meeting/UpdateMeetingUseCase";
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<UpdateMeetingCommand & { date: string }>;
+  errors: FieldErrors<UpdateMeetingCommand & { date: string }>;
+  loading?: boolean;
+}
+
+export const MeetingEditPresenter = ({ onCancel, handleSubmit, register, errors, loading }: Props) => (
+  <LayoutForm
+    title="Editar Reunión"
+    description="Editar la reunión"
+    breadcrumbs={[{ label: "Reuniones", href: "/reuniones" }, { label: "Editar" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Editar Reunión</CardTitle>
+          <CardDescription>Modifique los campos necesarios.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input type="hidden" {...register("id", { valueAsNumber: true })} />
+            <div className="grid grid-cols-1 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="topic">Tema *</Label>
+                <Input id="topic" {...register("topic", { required: "Obligatorio" })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="date">Fecha</Label>
+                <Input id="date" type="date" disabled {...register("date")} />
+              </div>
+            </div>
+            {errors.topic && <div className="text-destructive text-sm">{errors.topic.message}</div>}
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Actualizando..." : "Actualizar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/Meeting/List/MeetingListContainer.tsx
+++ b/src/academic/presentation/ui/Meeting/List/MeetingListContainer.tsx
@@ -1,0 +1,37 @@
+import { ListMeetingsCommand, ListMeetingsUseCase } from "@/academic/application/usecases/meeting/ListMeetingsUseCase";
+import { MeetingListPresenter } from "./MeetingListPresenter";
+import { MEETING_SYMBOLS } from "@/academic/domain/symbols/Meeting";
+import { useInjection } from "inversify-react";
+import { useCallback, useEffect, useState } from "react";
+import { Meeting } from "@/academic/domain/entities/Meeting";
+
+export const MeetingListContainer = () => {
+  const listUseCase = useInjection<ListMeetingsUseCase>(MEETING_SYMBOLS.LIST_USE_CASE);
+  const [meetings, setMeetings] = useState<Meeting[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const res = await listUseCase.execute(new ListMeetingsCommand());
+    res.ifRight(data => setMeetings(data ?? [])).ifLeft(f => setError(f.map(x => x.message).join(", ")));
+    setLoading(false);
+  }, [listUseCase]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const filtered = meetings.filter(m => m.topic.toLowerCase().includes(searchTerm.toLowerCase()));
+
+  return (
+    <MeetingListPresenter
+      meetings={filtered}
+      loading={loading}
+      error={error}
+      searchTerm={searchTerm}
+      onSearchChange={setSearchTerm}
+      onAddMeeting={() => {}}
+    />
+  );
+};

--- a/src/academic/presentation/ui/Meeting/List/MeetingListPresenter.tsx
+++ b/src/academic/presentation/ui/Meeting/List/MeetingListPresenter.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Search, Plus } from "lucide-react";
+import { Meeting } from "@/academic/domain/entities/Meeting";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Props {
+  meetings: Meeting[];
+  loading: boolean;
+  error: string | null;
+  searchTerm: string;
+  onSearchChange: (t: string) => void;
+  onAddMeeting: () => void;
+}
+
+export const MeetingListPresenter = ({ meetings, loading, error, searchTerm, onSearchChange, onAddMeeting }: Props) => (
+  <div className="space-y-6">
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-2xl font-bold">Reuniones</CardTitle>
+          <Button onClick={onAddMeeting} className="flex items-center gap-2">
+            <Plus className="h-4 w-4" /> Nueva
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2 mb-6">
+          <Search className="h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Buscar por tema" value={searchTerm} onChange={e => onSearchChange(e.target.value)} className="max-w-sm" />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {error && <div className="text-destructive text-center col-span-full">{error}</div>}
+          {meetings.map(m => (
+            <Card key={m.id} className="hover:shadow-md transition-shadow">
+              <CardContent className="p-4">
+                <p className="font-semibold">{m.topic}</p>
+                <p className="text-sm text-muted-foreground">{m.date}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        {meetings.length === 0 && !loading && !error && <div className="text-center py-8 text-muted-foreground">No se encontraron reuniones</div>}
+      </CardContent>
+    </Card>
+  </div>
+);

--- a/src/academic/presentation/ui/OfficialRecord/View/OfficialRecordViewContainer.tsx
+++ b/src/academic/presentation/ui/OfficialRecord/View/OfficialRecordViewContainer.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { useInjection } from "inversify-react";
+import { OfficialRecord } from "@/academic/domain/entities/OfficialRecord";
+import { GetOfficialRecordUseCase, GetOfficialRecordCommand } from "@/academic/application/usecases/official-record/GetOfficialRecordUseCase";
+import { AbstractFailure } from "@/academic/domain/entities/failure";
+import { OfficialRecordViewPresenter } from "./OfficialRecordViewPresenter";
+
+export function OfficialRecordViewContainer() {
+  const useCase = useInjection(GetOfficialRecordUseCase);
+  const [record, setRecord] = useState<OfficialRecord | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSearch = async (studentId: number) => {
+    setLoading(true);
+    setError(null);
+    const result = await useCase.execute(new GetOfficialRecordCommand(studentId));
+    result.caseOf({
+      Left: (f: AbstractFailure[]) => setError(f[0]?.message ?? "Error"),
+      Right: (r: OfficialRecord | undefined) => setRecord(r),
+    });
+    setLoading(false);
+  };
+
+  return (
+    <OfficialRecordViewPresenter
+      record={record}
+      loading={loading}
+      error={error}
+      onSearch={onSearch}
+    />
+  );
+}
+

--- a/src/academic/presentation/ui/OfficialRecord/View/OfficialRecordViewPresenter.tsx
+++ b/src/academic/presentation/ui/OfficialRecord/View/OfficialRecordViewPresenter.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { OfficialRecord } from "@/academic/domain/entities/OfficialRecord";
+
+interface Props {
+  record?: OfficialRecord;
+  loading: boolean;
+  error: string | null;
+  onSearch: (studentId: number) => void;
+}
+
+export function OfficialRecordViewPresenter({ record, loading, error, onSearch }: Props) {
+  const [studentId, setStudentId] = useState("");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Registro Oficial</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex gap-2 mb-4">
+          <Input
+            placeholder="ID de estudiante"
+            value={studentId}
+            onChange={(e) => setStudentId(e.target.value)}
+          />
+          <Button onClick={() => onSearch(Number(studentId))} disabled={loading}>
+            Consultar
+          </Button>
+        </div>
+        {error && <div className="text-destructive mb-4">{error}</div>}
+        {record && (
+          <pre className="bg-muted p-4 rounded text-sm overflow-auto">
+            {JSON.stringify(record, null, 2)}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/academic/presentation/ui/Promotion/Promote/PromotionPromoteContainer.tsx
+++ b/src/academic/presentation/ui/Promotion/Promote/PromotionPromoteContainer.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { useInjection } from "inversify-react";
+import { Promotion } from "@/academic/domain/entities/Promotion";
+import { PromoteStudentUseCase, PromoteStudentCommand } from "@/academic/application/usecases/promotion/PromoteStudentUseCase";
+import { AbstractFailure } from "@/academic/domain/entities/failure";
+import { PromotionPromotePresenter } from "./PromotionPromotePresenter";
+
+export function PromotionPromoteContainer() {
+  const useCase = useInjection(PromoteStudentUseCase);
+  const [result, setResult] = useState<Promotion | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onPromote = async (studentId: number, academicYearId: string) => {
+    setLoading(true);
+    setError(null);
+    const res = await useCase.execute(new PromoteStudentCommand(studentId, academicYearId));
+    res.caseOf({
+      Left: (f: AbstractFailure[]) => setError(f[0]?.message ?? "Error"),
+      Right: (r: Promotion | undefined) => setResult(r),
+    });
+    setLoading(false);
+  };
+
+  return (
+    <PromotionPromotePresenter
+      promotion={result}
+      loading={loading}
+      error={error}
+      onPromote={onPromote}
+    />
+  );
+}
+

--- a/src/academic/presentation/ui/Promotion/Promote/PromotionPromotePresenter.tsx
+++ b/src/academic/presentation/ui/Promotion/Promote/PromotionPromotePresenter.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Promotion } from "@/academic/domain/entities/Promotion";
+
+interface Props {
+  promotion?: Promotion;
+  loading: boolean;
+  error: string | null;
+  onPromote: (studentId: number, academicYearId: string) => void;
+}
+
+export function PromotionPromotePresenter({ promotion, loading, error, onPromote }: Props) {
+  const [studentId, setStudentId] = useState("");
+  const [year, setYear] = useState("");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Promoción de Estudiante</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col md:flex-row gap-2 mb-4">
+          <Input
+            placeholder="ID de estudiante"
+            value={studentId}
+            onChange={(e) => setStudentId(e.target.value)}
+          />
+          <Input
+            placeholder="Año académico"
+            value={year}
+            onChange={(e) => setYear(e.target.value)}
+          />
+          <Button onClick={() => onPromote(Number(studentId), year)} disabled={loading}>
+            Promocionar
+          </Button>
+        </div>
+        {error && <div className="text-destructive mb-4">{error}</div>}
+        {promotion && (
+          <pre className="bg-muted p-4 rounded text-sm overflow-auto">
+            {JSON.stringify(promotion, null, 2)}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/academic/presentation/ui/PromotionAct/Create/PromotionActCreateContainer.tsx
+++ b/src/academic/presentation/ui/PromotionAct/Create/PromotionActCreateContainer.tsx
@@ -1,0 +1,31 @@
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { PROMOTION_ACT_SYMBOLS } from "@/academic/domain/symbols/PromotionAct";
+import { CreatePromotionActCommand, CreatePromotionActUseCase } from "@/academic/application/usecases/promotion-act/CreatePromotionActUseCase";
+import { toast } from "@/hooks/use-toast";
+import { PromotionActCreatePresenter } from "./PromotionActCreatePresenter";
+
+export const PromotionActCreateContainer = () => {
+  const createUseCase = useInjection<CreatePromotionActUseCase>(PROMOTION_ACT_SYMBOLS.CREATE_USE_CASE);
+  const { register, handleSubmit, formState: { errors, isSubmitting }, reset } = useForm<CreatePromotionActCommand>();
+
+  const onSubmit = async (data: CreatePromotionActCommand) => {
+    const res = await createUseCase.execute(data);
+    res.ifRight(() => {
+      toast({ title: "Acta creada", description: "El acta de promoción ha sido creada", duration: 5000 });
+      reset();
+    }).ifLeft(failures => {
+      toast({ title: "Error", description: failures.map(f => f.message).join(", "), variant: "destructive", duration: 5000 });
+    });
+  };
+
+  return (
+    <PromotionActCreatePresenter
+      onCancel={() => {}}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+      loading={isSubmitting}
+    />
+  );
+};

--- a/src/academic/presentation/ui/PromotionAct/Create/PromotionActCreatePresenter.tsx
+++ b/src/academic/presentation/ui/PromotionAct/Create/PromotionActCreatePresenter.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { CreatePromotionActCommand } from "@/academic/application/usecases/promotion-act/CreatePromotionActUseCase";
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<CreatePromotionActCommand>;
+  errors: FieldErrors<CreatePromotionActCommand>;
+  loading?: boolean;
+}
+
+export const PromotionActCreatePresenter = ({ onCancel, handleSubmit, register, errors, loading }: Props) => (
+  <LayoutForm
+    title="Nueva Acta de Promoción"
+    description="Generar una nueva acta de promoción"
+    breadcrumbs={[{ label: "Actas de Promoción", href: "/actas-promocion" }, { label: "Nueva" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Generar Acta</CardTitle>
+          <CardDescription>Complete los campos para generar el acta.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="courseId">ID Curso *</Label>
+                <Input id="courseId" {...register("courseId", { required: "Obligatorio" })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="academicYearId">ID Año Académico *</Label>
+                <Input id="academicYearId" {...register("academicYearId", { required: "Obligatorio" })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="generatedBy">Generado Por (ID Usuario) *</Label>
+                <Input id="generatedBy" type="number" {...register("generatedBy", { valueAsNumber: true, required: "Obligatorio" })} />
+              </div>
+            </div>
+            {errors.courseId && <div className="text-destructive text-sm">{errors.courseId.message}</div>}
+            {errors.academicYearId && <div className="text-destructive text-sm">{errors.academicYearId.message}</div>}
+            {errors.generatedBy && <div className="text-destructive text-sm">{errors.generatedBy.message}</div>}
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Generando..." : "Generar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/PromotionAct/List/PromotionActListContainer.tsx
+++ b/src/academic/presentation/ui/PromotionAct/List/PromotionActListContainer.tsx
@@ -1,0 +1,40 @@
+import { ListPromotionActsCommand, ListPromotionActsUseCase } from "@/academic/application/usecases/promotion-act/ListPromotionActsUseCase";
+import { PROMOTION_ACT_SYMBOLS } from "@/academic/domain/symbols/PromotionAct";
+import { PromotionActListPresenter } from "./PromotionActListPresenter";
+import { useInjection } from "inversify-react";
+import { useCallback, useEffect, useState } from "react";
+import { PromotionAct } from "@/academic/domain/entities/PromotionAct";
+
+export const PromotionActListContainer = () => {
+  const listUseCase = useInjection<ListPromotionActsUseCase>(PROMOTION_ACT_SYMBOLS.LIST_USE_CASE);
+  const [acts, setActs] = useState<PromotionAct[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [courseId, setCourseId] = useState("");
+  const [yearId, setYearId] = useState("");
+
+  const fetchData = useCallback(async () => {
+    if (!courseId || !yearId) return;
+    setLoading(true);
+    setError(null);
+    const res = await listUseCase.execute(new ListPromotionActsCommand(courseId, yearId));
+    res.ifRight(data => setActs(data ?? [])).ifLeft(f => setError(f.map(x => x.message).join(", ")));
+    setLoading(false);
+  }, [listUseCase, courseId, yearId]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  return (
+    <PromotionActListPresenter
+      acts={acts}
+      loading={loading}
+      error={error}
+      courseId={courseId}
+      yearId={yearId}
+      onCourseChange={setCourseId}
+      onYearChange={setYearId}
+      onSearch={fetchData}
+      onAddAct={() => {}}
+    />
+  );
+};

--- a/src/academic/presentation/ui/PromotionAct/List/PromotionActListPresenter.tsx
+++ b/src/academic/presentation/ui/PromotionAct/List/PromotionActListPresenter.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { PromotionAct } from "@/academic/domain/entities/PromotionAct";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Plus } from "lucide-react";
+
+interface Props {
+  acts: PromotionAct[];
+  loading: boolean;
+  error: string | null;
+  courseId: string;
+  yearId: string;
+  onCourseChange: (t: string) => void;
+  onYearChange: (t: string) => void;
+  onSearch: () => void;
+  onAddAct: () => void;
+}
+
+export const PromotionActListPresenter = ({ acts, loading, error, courseId, yearId, onCourseChange, onYearChange, onSearch, onAddAct }: Props) => (
+  <div className="space-y-6">
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-2xl font-bold">Actas de Promoción</CardTitle>
+          <Button onClick={onAddAct} className="flex items-center gap-2"><Plus className="h-4 w-4" /> Nueva</Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2 mb-6">
+          <Input placeholder="ID Curso" value={courseId} onChange={e => onCourseChange(e.target.value)} className="max-w-xs" />
+          <Input placeholder="ID Año" value={yearId} onChange={e => onYearChange(e.target.value)} className="max-w-xs" />
+          <Button onClick={onSearch}>Buscar</Button>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {error && <div className="text-destructive text-center col-span-full">{error}</div>}
+          {acts.map(a => (
+            <Card key={a.id} className="hover:shadow-md transition-shadow">
+              <CardContent className="p-4">
+                <p className="font-semibold">Curso: {a.courseId}</p>
+                <p className="text-sm">Año: {a.academicYearId}</p>
+                <p className="text-sm">Generado por: {a.generatedBy}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        {acts.length === 0 && !loading && !error && <div className="text-center py-8 text-muted-foreground">No se encontraron actas</div>}
+      </CardContent>
+    </Card>
+  </div>
+);

--- a/src/academic/presentation/ui/ReportCard/View/ReportCardViewContainer.tsx
+++ b/src/academic/presentation/ui/ReportCard/View/ReportCardViewContainer.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { useInjection } from "inversify-react";
+import { ReportCard } from "@/academic/domain/entities/ReportCard";
+import { GetReportCardUseCase, GetReportCardCommand } from "@/academic/application/usecases/report-card/GetReportCardUseCase";
+import { AbstractFailure } from "@/academic/domain/entities/failure";
+import { ReportCardViewPresenter } from "./ReportCardViewPresenter";
+
+export function ReportCardViewContainer() {
+  const useCase = useInjection(GetReportCardUseCase);
+  const [report, setReport] = useState<ReportCard | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSearch = async (studentId: number, academicYearId: string) => {
+    setLoading(true);
+    setError(null);
+    const result = await useCase.execute(new GetReportCardCommand(studentId, academicYearId));
+    result.caseOf({
+      Left: (f: AbstractFailure[]) => setError(f[0]?.message ?? "Error"),
+      Right: (r: ReportCard | undefined) => setReport(r),
+    });
+    setLoading(false);
+  };
+
+  return (
+    <ReportCardViewPresenter
+      report={report}
+      loading={loading}
+      error={error}
+      onSearch={onSearch}
+    />
+  );
+}
+

--- a/src/academic/presentation/ui/ReportCard/View/ReportCardViewPresenter.tsx
+++ b/src/academic/presentation/ui/ReportCard/View/ReportCardViewPresenter.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { ReportCard } from "@/academic/domain/entities/ReportCard";
+
+interface Props {
+  report?: ReportCard;
+  loading: boolean;
+  error: string | null;
+  onSearch: (studentId: number, academicYearId: string) => void;
+}
+
+export function ReportCardViewPresenter({ report, loading, error, onSearch }: Props) {
+  const [studentId, setStudentId] = useState("");
+  const [year, setYear] = useState("");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Boleta de Calificaciones</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col md:flex-row gap-2 mb-4">
+          <Input
+            placeholder="ID de estudiante"
+            value={studentId}
+            onChange={(e) => setStudentId(e.target.value)}
+          />
+          <Input
+            placeholder="Año académico"
+            value={year}
+            onChange={(e) => setYear(e.target.value)}
+          />
+          <Button onClick={() => onSearch(Number(studentId), year)} disabled={loading}>
+            Consultar
+          </Button>
+        </div>
+        {error && <div className="text-destructive mb-4">{error}</div>}
+        {report && (
+          <pre className="bg-muted p-4 rounded text-sm overflow-auto">
+            {JSON.stringify(report, null, 2)}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/academic/presentation/ui/Representative/Create/RepresentativeCreateContainer.tsx
+++ b/src/academic/presentation/ui/Representative/Create/RepresentativeCreateContainer.tsx
@@ -1,0 +1,62 @@
+import { CreateRepresentativeCommand, CreateRepresentativeUseCase } from "@/academic/application/usecases/representative/CreateRepresentativeUseCase";
+import { useForm } from "react-hook-form";
+import { RepresentativeCreatePresenter } from "./RepresentativeCreatePresenter";
+import { useInjection } from "inversify-react";
+import { REPRESENTATIVE_SYMBOLS } from "@/academic/domain/symbols/Representative";
+import { toast } from "@/hooks/use-toast";
+
+export const RepresentativeCreateContainer = () => {
+    const createUseCase = useInjection<CreateRepresentativeUseCase>(REPRESENTATIVE_SYMBOLS.CREATE_USE_CASE);
+
+    const { register, handleSubmit, watch, formState: { isSubmitting } } = useForm<CreateRepresentativeCommand>({
+        defaultValues: {
+            firstName: "",
+            lastName: "",
+            phone: "",
+            birthDate: "",
+            uuidUser: "",
+            address: "",
+            identification: "",
+            nacionality: "",
+            gender: "",
+            image: "",
+        }
+    });
+
+    const formData = watch();
+
+    const onSubmit = async (data: CreateRepresentativeCommand) => {
+        const res = await createUseCase.execute(data);
+        res.ifRight((rep) => {
+            if (!rep) return;
+            toast({
+                title: "Representante creado",
+                description: `El representante ${rep.firstName} ${rep.lastName} ha sido creado con éxito.`,
+                duration: 5000,
+            });
+            onCancel();
+        }).ifLeft((failures) => {
+            toast({
+                title: "Error",
+                description: "Error al crear el representante: " + failures.map(f => f.message).join(", "),
+                duration: 5000,
+                variant: "destructive",
+            });
+        });
+    };
+
+    const onCancel = () => {
+        // Implement navigation or state reset logic here
+    };
+
+    return (
+        <RepresentativeCreatePresenter
+            onCancel={onCancel}
+            handleSubmit={handleSubmit(onSubmit)}
+            register={register}
+            loading={isSubmitting}
+            formData={formData}
+        />
+    );
+};
+

--- a/src/academic/presentation/ui/Representative/Create/RepresentativeCreatePresenter.tsx
+++ b/src/academic/presentation/ui/Representative/Create/RepresentativeCreatePresenter.tsx
@@ -1,0 +1,145 @@
+import { CreateRepresentativeCommand } from "@/academic/application/usecases/representative/CreateRepresentativeUseCase";
+import { GuidelinesList } from "@/components/GuidelinesList";
+import { LayoutForm } from "@/components/layout-form";
+import { PreviewCard } from "@/components/PreviewCard";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { AlertCircle, ShieldCheck } from "lucide-react";
+import { UseFormRegister } from "react-hook-form";
+
+interface RepresentativeCreatePresenterProps {
+    onCancel: () => void;
+    handleSubmit: React.FormEventHandler<HTMLFormElement>;
+    register: UseFormRegister<CreateRepresentativeCommand>;
+    loading?: boolean;
+    formData: CreateRepresentativeCommand;
+}
+
+export const RepresentativeCreatePresenter = ({
+    onCancel,
+    handleSubmit,
+    register,
+    loading,
+    formData,
+}: RepresentativeCreatePresenterProps) => {
+    return (
+        <LayoutForm
+            title="Nuevo Representante"
+            description="Completa los campos para registrar un nuevo representante."
+            breadcrumbs={[
+                { label: "Representantes", href: "/representantes" },
+                { label: "Nuevo Representante" }
+            ]}
+            main={
+                <div className="lg:col-span-2">
+                    <Card>
+                        <CardHeader className="pb-3">
+                            <CardTitle>Registrar Representante</CardTitle>
+                            <CardDescription>
+                                Completa los campos para crear un nuevo representante. Asegúrate de que toda la información sea correcta antes de guardar.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <form onSubmit={handleSubmit} className="space-y-4">
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <div className="space-y-2">
+                                        <Label htmlFor="firstName">Nombre *</Label>
+                                        <Input
+                                            id="firstName"
+                                            {...register("firstName", { required: "El nombre es obligatorio" })}
+                                        />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="lastName">Apellido *</Label>
+                                        <Input
+                                            id="lastName"
+                                            {...register("lastName", { required: "El apellido es obligatorio" })}
+                                        />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="identification">Identificación</Label>
+                                        <Input id="identification" {...register("identification")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="phone">Teléfono</Label>
+                                        <Input id="phone" {...register("phone")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="birthDate">Fecha de Nacimiento</Label>
+                                        <Input id="birthDate" type="date" {...register("birthDate")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="gender">Género</Label>
+                                        <Input id="gender" {...register("gender")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="nacionality">Nacionalidad</Label>
+                                        <Input id="nacionality" {...register("nacionality")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="address">Dirección</Label>
+                                        <Input id="address" {...register("address")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="uuidUser">UUID Usuario</Label>
+                                        <Input id="uuidUser" {...register("uuidUser")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="image">Imagen (URL)</Label>
+                                        <Input id="image" {...register("image")} />
+                                    </div>
+                                </div>
+                                <div className="flex gap-2 pt-4">
+                                    <Button type="submit" disabled={loading} className="flex-1">
+                                        {loading ? "Guardando..." : "Guardar"}
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={onCancel}
+                                        className="flex-1 bg-transparent"
+                                    >
+                                        Cancelar
+                                    </Button>
+                                </div>
+                            </form>
+                        </CardContent>
+                    </Card>
+                </div>
+            }
+            sidebar={
+                <>
+                    <PreviewCard
+                        title="Vista Previa"
+                        description="Vista previa del representante que estás registrando. Verifica que los datos sean correctos antes de guardar."
+                        icon={<ShieldCheck className="h-5 w-5 text-primary-500" />}
+                        headerText={`${formData.firstName} ${formData.lastName || "Nombre del representante"}`}
+                        badgeText="Activo"
+                        badgeClassName="bg-accent-300 text-accent-800 hover:bg-accent-400 border-accent-500"
+                        fields={[
+                            { label: "Teléfono", value: formData.phone, fallback: "Sin teléfono" },
+                            { label: "Identificación", value: formData.identification, fallback: "Sin identificación" },
+                            { label: "Nacionalidad", value: formData.nacionality, fallback: "Sin nacionalidad" },
+                        ]}
+                    />
+                    <Card>
+                        <CardHeader className="pb-3">
+                            <CardTitle>Guía de Mejores Prácticas</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <GuidelinesList
+                                items={[
+                                    { text: "Verifique que el nombre y apellido estén correctamente escritos" },
+                                    { text: "No deje campos obligatorios vacíos", variant: "danger", icon: <AlertCircle className="h-4 w-4 text-destructive" /> },
+                                ]}
+                            />
+                        </CardContent>
+                    </Card>
+                </>
+            }
+        />
+    );
+};
+

--- a/src/academic/presentation/ui/Representative/Edit/RepresentativeEditContainer.tsx
+++ b/src/academic/presentation/ui/Representative/Edit/RepresentativeEditContainer.tsx
@@ -1,0 +1,81 @@
+import { useForm } from "react-hook-form";
+import { RepresentativeEditPresenter } from "./RepresentativeEditPresenter";
+import { UpdateRepresentativeCommand, UpdateRepresentativeUseCase } from "@/academic/application/usecases/representative/UpdateRepresentativeUseCase";
+import { useInjection } from "inversify-react";
+import { REPRESENTATIVE_SYMBOLS } from "@/academic/domain/symbols/Representative";
+import { useParams } from "react-router";
+import { GetRepresentativeCommand, GetRepresentativeUseCase } from "@/academic/application/usecases/representative/GetRepresentativeUseCase";
+import { useCallback, useEffect } from "react";
+import { toast } from "@/hooks/use-toast";
+
+export const RepresentativeEditContainer = () => {
+    const { id } = useParams();
+
+    const updateUseCase = useInjection<UpdateRepresentativeUseCase>(REPRESENTATIVE_SYMBOLS.UPDATE_USE_CASE);
+    const getUseCase = useInjection<GetRepresentativeUseCase>(REPRESENTATIVE_SYMBOLS.GET_USE_CASE);
+
+    const { handleSubmit, register, watch, setValue, formState: { isSubmitting } } = useForm<UpdateRepresentativeCommand>();
+
+    const formData = watch();
+
+    const fetchRepresentative = useCallback(async () => {
+        if (!id) return;
+        const res = await getUseCase.execute(new GetRepresentativeCommand(Number(id)));
+        res.ifRight((rep) => {
+            if (!rep) return;
+            setValue("id", rep.id);
+            setValue("firstName", rep.firstName);
+            setValue("lastName", rep.lastName);
+            setValue("phone", rep.phone || "");
+            setValue("birthDate", rep.birthDate || "");
+            setValue("uuidUser", rep.uuidUser || "");
+            setValue("address", rep.address || "");
+            setValue("identification", rep.identification || "");
+            setValue("nacionality", rep.nacionality || "");
+            setValue("gender", rep.gender || "");
+            setValue("image", rep.image || "");
+        });
+        res.ifLeft((failures) => {
+            toast({
+                title: "Error",
+                description: "Error al obtener el representante: " + failures.map(f => f.message).join(", "),
+                duration: 5000,
+                variant: "destructive",
+            });
+        });
+    }, [getUseCase, id, setValue]);
+
+    useEffect(() => {
+        fetchRepresentative();
+    }, [fetchRepresentative]);
+
+    const onSubmit = async (data: UpdateRepresentativeCommand) => {
+        const res = await updateUseCase.execute(data);
+        res.ifRight((rep) => {
+            toast({
+                title: "Representante actualizado",
+                description: `El representante ${rep?.firstName} ${rep?.lastName} ha sido actualizado.`,
+                duration: 5000,
+            });
+        });
+        res.ifLeft((failures) => {
+            toast({
+                title: "Error",
+                description: "Error al actualizar el representante: " + failures.map(f => f.message).join(", "),
+                duration: 5000,
+                variant: "destructive",
+            });
+        });
+    };
+
+    return (
+        <RepresentativeEditPresenter
+            onCancel={() => { }}
+            handleSubmit={handleSubmit(onSubmit)}
+            register={register}
+            loading={isSubmitting}
+            formData={formData}
+        />
+    );
+};
+

--- a/src/academic/presentation/ui/Representative/Edit/RepresentativeEditPresenter.tsx
+++ b/src/academic/presentation/ui/Representative/Edit/RepresentativeEditPresenter.tsx
@@ -1,0 +1,145 @@
+import { UpdateRepresentativeCommand } from "@/academic/application/usecases/representative/UpdateRepresentativeUseCase";
+import { GuidelinesList } from "@/components/GuidelinesList";
+import { LayoutForm } from "@/components/layout-form";
+import { PreviewCard } from "@/components/PreviewCard";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { AlertCircle, ShieldCheck } from "lucide-react";
+import { UseFormRegister } from "react-hook-form";
+
+interface RepresentativeEditPresenterProps {
+    onCancel: () => void;
+    handleSubmit: React.FormEventHandler<HTMLFormElement>;
+    register: UseFormRegister<UpdateRepresentativeCommand>;
+    loading?: boolean;
+    formData: UpdateRepresentativeCommand;
+}
+
+export const RepresentativeEditPresenter = ({
+    onCancel,
+    handleSubmit,
+    register,
+    loading,
+    formData,
+}: RepresentativeEditPresenterProps) => {
+    return (
+        <LayoutForm
+            title="Editar Representante"
+            description="Actualiza los datos del representante."
+            breadcrumbs={[
+                { label: "Representantes", href: "/representantes" },
+                { label: "Editar Representante" }
+            ]}
+            main={
+                <div className="lg:col-span-2">
+                    <Card>
+                        <CardHeader className="pb-3">
+                            <CardTitle>Editar Representante</CardTitle>
+                            <CardDescription>
+                                Modifica los campos necesarios y guarda los cambios.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <form onSubmit={handleSubmit} className="space-y-4">
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <div className="space-y-2">
+                                        <Label htmlFor="firstName">Nombre *</Label>
+                                        <Input
+                                            id="firstName"
+                                            {...register("firstName", { required: "El nombre es obligatorio" })}
+                                        />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="lastName">Apellido *</Label>
+                                        <Input
+                                            id="lastName"
+                                            {...register("lastName", { required: "El apellido es obligatorio" })}
+                                        />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="identification">Identificación</Label>
+                                        <Input id="identification" {...register("identification")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="phone">Teléfono</Label>
+                                        <Input id="phone" {...register("phone")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="birthDate">Fecha de Nacimiento</Label>
+                                        <Input id="birthDate" type="date" {...register("birthDate")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="gender">Género</Label>
+                                        <Input id="gender" {...register("gender")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="nacionality">Nacionalidad</Label>
+                                        <Input id="nacionality" {...register("nacionality")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="address">Dirección</Label>
+                                        <Input id="address" {...register("address")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="uuidUser">UUID Usuario</Label>
+                                        <Input id="uuidUser" {...register("uuidUser")} />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="image">Imagen (URL)</Label>
+                                        <Input id="image" {...register("image")} />
+                                    </div>
+                                </div>
+                                <div className="flex gap-2 pt-4">
+                                    <Button type="submit" disabled={loading} className="flex-1">
+                                        {loading ? "Guardando..." : "Guardar"}
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={onCancel}
+                                        className="flex-1 bg-transparent"
+                                    >
+                                        Cancelar
+                                    </Button>
+                                </div>
+                            </form>
+                        </CardContent>
+                    </Card>
+                </div>
+            }
+            sidebar={
+                <>
+                    <PreviewCard
+                        title="Vista Previa"
+                        description="Revisa los datos del representante antes de guardar."
+                        icon={<ShieldCheck className="h-5 w-5 text-primary-500" />}
+                        headerText={`${formData.firstName} ${formData.lastName || "Nombre del representante"}`}
+                        badgeText="Activo"
+                        badgeClassName="bg-accent-300 text-accent-800 hover:bg-accent-400 border-accent-500"
+                        fields={[
+                            { label: "Teléfono", value: formData.phone, fallback: "Sin teléfono" },
+                            { label: "Identificación", value: formData.identification, fallback: "Sin identificación" },
+                            { label: "Nacionalidad", value: formData.nacionality, fallback: "Sin nacionalidad" },
+                        ]}
+                    />
+                    <Card>
+                        <CardHeader className="pb-3">
+                            <CardTitle>Guía de Mejores Prácticas</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <GuidelinesList
+                                items={[
+                                    { text: "Verifique que los datos sean correctos" },
+                                    { text: "No deje campos obligatorios vacíos", variant: "danger", icon: <AlertCircle className="h-4 w-4 text-destructive" /> },
+                                ]}
+                            />
+                        </CardContent>
+                    </Card>
+                </>
+            }
+        />
+    );
+};
+

--- a/src/academic/presentation/ui/Representative/List/RepresentativeListContainer.tsx
+++ b/src/academic/presentation/ui/Representative/List/RepresentativeListContainer.tsx
@@ -1,0 +1,51 @@
+import { ListRepresentativesCommand, ListRepresentativesUseCase } from "@/academic/application/usecases/representative/ListRepresentativesUseCase";
+import { RepresentativeListPresenter } from "./RepresentativeListPresenter";
+import { useInjection } from "inversify-react";
+import { REPRESENTATIVE_SYMBOLS } from "@/academic/domain/symbols/Representative";
+import { useCallback, useEffect, useState } from "react";
+import { Representative } from "@/academic/domain/entities/Representative";
+
+export const RepresentativeListContainer = () => {
+    const listUseCase = useInjection<ListRepresentativesUseCase>(REPRESENTATIVE_SYMBOLS.LIST_USE_CASE);
+
+    const [representatives, setRepresentatives] = useState<Representative[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [searchTerm, setSearchTerm] = useState("");
+
+    const fetchRepresentatives = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        const res = await listUseCase.execute(new ListRepresentativesCommand(1, 10));
+        res.ifRight(data => {
+            setRepresentatives(data ?? []);
+        }).ifLeft(failures => {
+            setError(failures.map(f => f.message).join(", "));
+        });
+        setLoading(false);
+    }, [listUseCase]);
+
+    useEffect(() => {
+        fetchRepresentatives();
+    }, [fetchRepresentatives]);
+
+    const handleSearchChange = (term: string) => {
+        setSearchTerm(term);
+    };
+
+    const filteredReps = representatives.filter(r =>
+        `${r.firstName} ${r.lastName}`.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    return (
+        <RepresentativeListPresenter
+            representatives={filteredReps}
+            loading={loading}
+            error={error}
+            onAddRepresentative={() => { }}
+            onSearchChange={handleSearchChange}
+            searchTerm={searchTerm}
+        />
+    );
+};
+

--- a/src/academic/presentation/ui/Representative/List/RepresentativeListPresenter.tsx
+++ b/src/academic/presentation/ui/Representative/List/RepresentativeListPresenter.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Search, Plus } from "lucide-react";
+import { Representative } from "@/academic/domain/entities/Representative";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface RepresentativeListPresenterProps {
+    representatives: Representative[];
+    loading: boolean;
+    error: string | null;
+    searchTerm: string;
+    onSearchChange: (term: string) => void;
+    onAddRepresentative: () => void;
+}
+
+export function RepresentativeListPresenter({
+    representatives,
+    loading,
+    error,
+    searchTerm,
+    onSearchChange,
+    onAddRepresentative,
+}: RepresentativeListPresenterProps) {
+    return (
+        <div className="space-y-6">
+            <Card>
+                <CardHeader>
+                    <div className="flex items-center justify-between">
+                        <CardTitle className="text-2xl font-bold">Representantes</CardTitle>
+                        <Button onClick={onAddRepresentative} className="flex items-center gap-2">
+                            <Plus className="h-4 w-4" />
+                            Agregar Representante
+                        </Button>
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    <div className="flex items-center gap-2 mb-6">
+                        <Search className="h-4 w-4 text-muted-foreground" />
+                        <Input
+                            placeholder="Buscar representantes..."
+                            value={searchTerm}
+                            onChange={(e) => onSearchChange(e.target.value)}
+                            className="max-w-sm"
+                        />
+                    </div>
+
+                    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                        {loading && <Skeleton className="h-24 w-full col-span-full" />}
+                        {error && (
+                            <div className="text-destructive text-center col-span-full">{error}</div>
+                        )}
+                        {representatives.map((rep) => (
+                            <Card key={rep.id} className="hover:shadow-md transition-shadow">
+                                <CardContent className="p-4">
+                                    <div className="flex items-start gap-3">
+                                        <Avatar className="h-12 w-12">
+                                            <AvatarImage
+                                                src="/placeholder.svg"
+                                                alt={`${rep.firstName} ${rep.lastName}`}
+                                            />
+                                            <AvatarFallback>
+                                                {rep.firstName[0]}
+                                                {rep.lastName[0]}
+                                            </AvatarFallback>
+                                        </Avatar>
+                                        <div className="flex-1 min-w-0">
+                                            <h3 className="font-semibold text-sm truncate">
+                                                {rep.firstName} {rep.lastName}
+                                            </h3>
+                                        </div>
+                                    </div>
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
+
+                    {representatives.length === 0 && !loading && !error && (
+                        <div className="text-center py-8 text-muted-foreground">
+                            No se encontraron representantes
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+

--- a/src/academic/presentation/ui/Statistics/Attendance/AttendanceStatisticsContainer.tsx
+++ b/src/academic/presentation/ui/Statistics/Attendance/AttendanceStatisticsContainer.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { useInjection } from "inversify-react";
+import { AttendanceStatistics } from "@/academic/domain/entities/Statistics";
+import { GetAttendanceStatisticsUseCase, GetAttendanceStatisticsCommand } from "@/academic/application/usecases/statistics/GetAttendanceStatisticsUseCase";
+import { AbstractFailure } from "@/academic/domain/entities/failure";
+import { AttendanceStatisticsPresenter } from "./AttendanceStatisticsPresenter";
+
+export function AttendanceStatisticsContainer() {
+  const useCase = useInjection(GetAttendanceStatisticsUseCase);
+  const [stats, setStats] = useState<AttendanceStatistics | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSearch = async (courseId: string, academicYearId: string) => {
+    setLoading(true);
+    setError(null);
+    const res = await useCase.execute(new GetAttendanceStatisticsCommand(courseId, academicYearId));
+    res.caseOf({
+      Left: (f: AbstractFailure[]) => setError(f[0]?.message ?? "Error"),
+      Right: (s: AttendanceStatistics | undefined) => setStats(s),
+    });
+    setLoading(false);
+  };
+
+  return (
+    <AttendanceStatisticsPresenter
+      stats={stats}
+      loading={loading}
+      error={error}
+      onSearch={onSearch}
+    />
+  );
+}
+

--- a/src/academic/presentation/ui/Statistics/Attendance/AttendanceStatisticsPresenter.tsx
+++ b/src/academic/presentation/ui/Statistics/Attendance/AttendanceStatisticsPresenter.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { AttendanceStatistics } from "@/academic/domain/entities/Statistics";
+
+interface Props {
+  stats?: AttendanceStatistics;
+  loading: boolean;
+  error: string | null;
+  onSearch: (courseId: string, academicYearId: string) => void;
+}
+
+export function AttendanceStatisticsPresenter({ stats, loading, error, onSearch }: Props) {
+  const [course, setCourse] = useState("");
+  const [year, setYear] = useState("");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Estadísticas de Asistencia</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col md:flex-row gap-2 mb-4">
+          <Input placeholder="Curso" value={course} onChange={(e) => setCourse(e.target.value)} />
+          <Input placeholder="Año académico" value={year} onChange={(e) => setYear(e.target.value)} />
+          <Button onClick={() => onSearch(course, year)} disabled={loading}>Consultar</Button>
+        </div>
+        {error && <div className="text-destructive mb-4">{error}</div>}
+        {stats && (
+          <pre className="bg-muted p-4 rounded text-sm overflow-auto">
+            {JSON.stringify(stats, null, 2)}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/academic/presentation/ui/Statistics/Performance/PerformanceStatisticsContainer.tsx
+++ b/src/academic/presentation/ui/Statistics/Performance/PerformanceStatisticsContainer.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { useInjection } from "inversify-react";
+import { PerformanceStatistics } from "@/academic/domain/entities/Statistics";
+import { GetPerformanceStatisticsUseCase, GetPerformanceStatisticsCommand } from "@/academic/application/usecases/statistics/GetPerformanceStatisticsUseCase";
+import { AbstractFailure } from "@/academic/domain/entities/failure";
+import { PerformanceStatisticsPresenter } from "./PerformanceStatisticsPresenter";
+
+export function PerformanceStatisticsContainer() {
+  const useCase = useInjection(GetPerformanceStatisticsUseCase);
+  const [stats, setStats] = useState<PerformanceStatistics | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSearch = async (courseId: string, subjectId: string, academicYearId: string) => {
+    setLoading(true);
+    setError(null);
+    const res = await useCase.execute(new GetPerformanceStatisticsCommand(courseId, subjectId, academicYearId));
+    res.caseOf({
+      Left: (f: AbstractFailure[]) => setError(f[0]?.message ?? "Error"),
+      Right: (s: PerformanceStatistics | undefined) => setStats(s),
+    });
+    setLoading(false);
+  };
+
+  return (
+    <PerformanceStatisticsPresenter
+      stats={stats}
+      loading={loading}
+      error={error}
+      onSearch={onSearch}
+    />
+  );
+}
+

--- a/src/academic/presentation/ui/Statistics/Performance/PerformanceStatisticsPresenter.tsx
+++ b/src/academic/presentation/ui/Statistics/Performance/PerformanceStatisticsPresenter.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { PerformanceStatistics } from "@/academic/domain/entities/Statistics";
+
+interface Props {
+  stats?: PerformanceStatistics;
+  loading: boolean;
+  error: string | null;
+  onSearch: (courseId: string, subjectId: string, academicYearId: string) => void;
+}
+
+export function PerformanceStatisticsPresenter({ stats, loading, error, onSearch }: Props) {
+  const [course, setCourse] = useState("");
+  const [subject, setSubject] = useState("");
+  const [year, setYear] = useState("");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Estadísticas de Rendimiento</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col md:flex-row gap-2 mb-4">
+          <Input placeholder="Curso" value={course} onChange={(e) => setCourse(e.target.value)} />
+          <Input placeholder="Materia" value={subject} onChange={(e) => setSubject(e.target.value)} />
+          <Input placeholder="Año académico" value={year} onChange={(e) => setYear(e.target.value)} />
+          <Button onClick={() => onSearch(course, subject, year)} disabled={loading}>Consultar</Button>
+        </div>
+        {error && <div className="text-destructive mb-4">{error}</div>}
+        {stats && (
+          <pre className="bg-muted p-4 rounded text-sm overflow-auto">
+            {JSON.stringify(stats, null, 2)}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/academic/presentation/ui/Student/Create/StudentCreateContainer.tsx
+++ b/src/academic/presentation/ui/Student/Create/StudentCreateContainer.tsx
@@ -1,0 +1,56 @@
+import { CreateStudentCommand, CreateStudentUseCase } from "@/academic/application/usecases/student/CreateStudentUseCase";
+import { useForm } from "react-hook-form";
+import { StudentCreatePresenter } from "./StudentCreatePresenter";
+import { useInjection } from "inversify-react";
+import { STUDENT_SYMBOLS } from "@/academic/domain/symbols/Student";
+import { toast } from "@/hooks/use-toast";
+
+export const StudentCreateContainer = () => {
+    const createStudentUsecase = useInjection<CreateStudentUseCase>(STUDENT_SYMBOLS.CREATE_USE_CASE);
+
+    const { register, handleSubmit, watch, formState: { errors, isSubmitting } } = useForm<CreateStudentCommand>({
+        defaultValues: {
+            firstName: "",
+            lastName: "",
+            uuidParallel: "",
+        }
+    });
+
+    const formData = watch();
+
+    const onSubmit = async (data: CreateStudentCommand) => {
+        const result = await createStudentUsecase.execute(data);
+        result.ifRight((student) => {
+            if (!student) return;
+            toast({
+                title: "Estudiante creado",
+                description: `El estudiante ${student.firstName} ${student.lastName} ha sido creado con éxito.`,
+                duration: 5000,
+            });
+            onCancel();
+        }).ifLeft((failures) => {
+            toast({
+                title: "Error",
+                description: "Error al crear el estudiante: " + failures.map(f => f.message).join(", "),
+                duration: 5000,
+                variant: "destructive"
+            });
+        });
+    };
+
+    const onCancel = () => {
+        // Implement navigation or state reset logic here
+    };
+
+    return (
+        <StudentCreatePresenter
+            onCancel={onCancel}
+            handleSubmit={handleSubmit(onSubmit)}
+            register={register}
+            errors={errors}
+            loading={isSubmitting}
+            formData={formData}
+        />
+    );
+};
+

--- a/src/academic/presentation/ui/Student/Create/StudentCreatePresenter.tsx
+++ b/src/academic/presentation/ui/Student/Create/StudentCreatePresenter.tsx
@@ -1,0 +1,124 @@
+import { CreateStudentCommand } from "@/academic/application/usecases/student/CreateStudentUseCase";
+import { GuidelinesList } from "@/components/GuidelinesList";
+import { LayoutForm } from "@/components/layout-form";
+import { PreviewCard } from "@/components/PreviewCard";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { AlertCircle, ShieldCheck } from "lucide-react";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface StudentCreatePresenterProps {
+    onCancel: () => void;
+    handleSubmit: React.FormEventHandler<HTMLFormElement>;
+    register: UseFormRegister<CreateStudentCommand>;
+    errors: FieldErrors<CreateStudentCommand>;
+    loading?: boolean;
+    formData: CreateStudentCommand;
+}
+
+export const StudentCreatePresenter = ({
+    onCancel,
+    handleSubmit,
+    register,
+    errors,
+    loading,
+    formData,
+}: StudentCreatePresenterProps) => {
+    return (
+        <LayoutForm
+            title="Nuevo Estudiante"
+            description="Completa los campos para registrar un nuevo estudiante."
+            breadcrumbs={[
+                { label: "Estudiantes", href: "/estudiantes" },
+                { label: "Nuevo Estudiante" }
+            ]}
+            main={
+                <div className="lg:col-span-2">
+                    <Card>
+                        <CardHeader className="pb-3">
+                            <CardTitle>Registrar Estudiante</CardTitle>
+                            <CardDescription>
+                                Completa los campos para crear un nuevo estudiante. Asegúrate de que toda la información sea correcta antes de guardar.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <form onSubmit={handleSubmit} className="space-y-4">
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <div className="space-y-2">
+                                        <Label htmlFor="firstName">Nombre *</Label>
+                                        <Input
+                                            id="firstName"
+                                            {...register("firstName", { required: "El nombre es obligatorio" })}
+                                        />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="lastName">Apellido *</Label>
+                                        <Input
+                                            id="lastName"
+                                            {...register("lastName", { required: "El apellido es obligatorio" })}
+                                        />
+                                    </div>
+                                    <div className="space-y-2 md:col-span-2">
+                                        <Label htmlFor="uuidParallel">Paralelo *</Label>
+                                        <Input
+                                            id="uuidParallel"
+                                            {...register("uuidParallel", { required: "El paralelo es obligatorio" })}
+                                        />
+                                    </div>
+                                </div>
+                                {errors.uuidParallel && (
+                                    <div className="text-destructive text-sm">{errors.uuidParallel.message}</div>
+                                )}
+                                <div className="flex gap-2 pt-4">
+                                    <Button type="submit" disabled={loading} className="flex-1">
+                                        {loading ? "Guardando..." : "Guardar"}
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={onCancel}
+                                        className="flex-1 bg-transparent"
+                                    >
+                                        Cancelar
+                                    </Button>
+                                </div>
+                            </form>
+                        </CardContent>
+                    </Card>
+                </div>
+            }
+            sidebar={
+                <>
+                    <PreviewCard
+                        title="Vista Previa"
+                        description="Vista previa del estudiante que estás registrando. Verifica que los datos sean correctos antes de guardar."
+                        icon={<ShieldCheck className="h-5 w-5 text-primary-500" />}
+                        headerText={`${formData.firstName} ${formData.lastName || "Nombre del estudiante"}`}
+                        badgeText="Activo"
+                        badgeClassName="bg-accent-300 text-accent-800 hover:bg-accent-400 border-accent-500"
+                        fields={[
+                            { label: "Paralelo", value: formData.uuidParallel, fallback: "Sin paralelo" },
+                        ]}
+                    />
+                    <Card>
+                        <CardHeader className="pb-3">
+                            <CardTitle>Guía de Mejores Prácticas</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <GuidelinesList
+                                items={[
+                                    { text: "Verifique que el nombre y apellido estén correctamente escritos" },
+                                    { text: "Asegúrese de ingresar un paralelo válido" },
+                                    { text: "No deje campos obligatorios vacíos", variant: "danger", icon: <AlertCircle className="h-4 w-4 text-destructive" /> },
+                                ]}
+                            />
+                        </CardContent>
+                    </Card>
+                </>
+            }
+        />
+    );
+};
+

--- a/src/academic/presentation/ui/Student/Edit/StudentEditContainer.tsx
+++ b/src/academic/presentation/ui/Student/Edit/StudentEditContainer.tsx
@@ -1,0 +1,75 @@
+import { useForm } from "react-hook-form";
+import { StudentEditPresenter } from "./StudentEditPresenter";
+import { UpdateStudentCommand, UpdateStudentUseCase } from "@/academic/application/usecases/student/UpdateStudentUseCase";
+import { useInjection } from "inversify-react";
+import { STUDENT_SYMBOLS } from "@/academic/domain/symbols/Student";
+import { useParams } from "react-router";
+import { GetStudentCommand, GetStudentUseCase } from "@/academic/application/usecases/student/GetStudentUseCase";
+import { useCallback, useEffect } from "react";
+import { toast } from "@/hooks/use-toast";
+
+export const StudentEditContainer = () => {
+    const { id } = useParams();
+
+    const updateUseCase = useInjection<UpdateStudentUseCase>(STUDENT_SYMBOLS.UPDATE_USE_CASE);
+    const getUseCase = useInjection<GetStudentUseCase>(STUDENT_SYMBOLS.GET_USE_CASE);
+
+    const { handleSubmit, register, watch, setValue, formState: { errors, isSubmitting } } = useForm<UpdateStudentCommand>();
+
+    const formData = watch();
+
+    const fetchStudent = useCallback(async () => {
+        if (!id) return;
+        const res = await getUseCase.execute(new GetStudentCommand(Number(id)));
+        res.ifRight((student) => {
+            if (!student) return;
+            setValue("id", student.id);
+            setValue("firstName", student.firstName);
+            setValue("lastName", student.lastName);
+            setValue("uuidParallel", student.uuidParallel);
+        });
+        res.ifLeft((failures) => {
+            toast({
+                title: "Error",
+                description: "Error al obtener el estudiante: " + failures.map(f => f.message).join(", "),
+                duration: 5000,
+                variant: "destructive",
+            });
+        });
+    }, [getUseCase, id, setValue]);
+
+    useEffect(() => {
+        fetchStudent();
+    }, [fetchStudent]);
+
+    const onSubmit = async (data: UpdateStudentCommand) => {
+        const res = await updateUseCase.execute(data);
+        res.ifRight((student) => {
+            toast({
+                title: "Estudiante actualizado",
+                description: `El estudiante ${student?.firstName} ${student?.lastName} ha sido actualizado.`,
+                duration: 5000,
+            });
+        });
+        res.ifLeft((failures) => {
+            toast({
+                title: "Error",
+                description: "Error al actualizar el estudiante: " + failures.map(f => f.message).join(", "),
+                duration: 5000,
+                variant: "destructive",
+            });
+        });
+    };
+
+    return (
+        <StudentEditPresenter
+            onCancel={() => { }}
+            handleSubmit={handleSubmit(onSubmit)}
+            register={register}
+            errors={errors}
+            loading={isSubmitting}
+            formData={formData}
+        />
+    );
+};
+

--- a/src/academic/presentation/ui/Student/Edit/StudentEditPresenter.tsx
+++ b/src/academic/presentation/ui/Student/Edit/StudentEditPresenter.tsx
@@ -1,0 +1,124 @@
+import { UpdateStudentCommand } from "@/academic/application/usecases/student/UpdateStudentUseCase";
+import { GuidelinesList } from "@/components/GuidelinesList";
+import { LayoutForm } from "@/components/layout-form";
+import { PreviewCard } from "@/components/PreviewCard";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { AlertCircle, ShieldCheck } from "lucide-react";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface StudentEditPresenterProps {
+    onCancel: () => void;
+    handleSubmit: React.FormEventHandler<HTMLFormElement>;
+    register: UseFormRegister<UpdateStudentCommand>;
+    errors: FieldErrors<UpdateStudentCommand>;
+    loading?: boolean;
+    formData: UpdateStudentCommand;
+}
+
+export const StudentEditPresenter = ({
+    onCancel,
+    handleSubmit,
+    register,
+    errors,
+    loading,
+    formData,
+}: StudentEditPresenterProps) => {
+    return (
+        <LayoutForm
+            title="Editar Estudiante"
+            description="Actualiza los datos del estudiante."
+            breadcrumbs={[
+                { label: "Estudiantes", href: "/estudiantes" },
+                { label: "Editar Estudiante" }
+            ]}
+            main={
+                <div className="lg:col-span-2">
+                    <Card>
+                        <CardHeader className="pb-3">
+                            <CardTitle>Editar Estudiante</CardTitle>
+                            <CardDescription>
+                                Modifica los campos necesarios y guarda los cambios.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <form onSubmit={handleSubmit} className="space-y-4">
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <div className="space-y-2">
+                                        <Label htmlFor="firstName">Nombre *</Label>
+                                        <Input
+                                            id="firstName"
+                                            {...register("firstName", { required: "El nombre es obligatorio" })}
+                                        />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="lastName">Apellido *</Label>
+                                        <Input
+                                            id="lastName"
+                                            {...register("lastName", { required: "El apellido es obligatorio" })}
+                                        />
+                                    </div>
+                                    <div className="space-y-2 md:col-span-2">
+                                        <Label htmlFor="uuidParallel">Paralelo *</Label>
+                                        <Input
+                                            id="uuidParallel"
+                                            {...register("uuidParallel", { required: "El paralelo es obligatorio" })}
+                                        />
+                                    </div>
+                                </div>
+                                {errors.uuidParallel && (
+                                    <div className="text-destructive text-sm">{errors.uuidParallel.message}</div>
+                                )}
+                                <div className="flex gap-2 pt-4">
+                                    <Button type="submit" disabled={loading} className="flex-1">
+                                        {loading ? "Guardando..." : "Guardar"}
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={onCancel}
+                                        className="flex-1 bg-transparent"
+                                    >
+                                        Cancelar
+                                    </Button>
+                                </div>
+                            </form>
+                        </CardContent>
+                    </Card>
+                </div>
+            }
+            sidebar={
+                <>
+                    <PreviewCard
+                        title="Vista Previa"
+                        description="Revisa los datos del estudiante antes de guardar."
+                        icon={<ShieldCheck className="h-5 w-5 text-primary-500" />}
+                        headerText={`${formData.firstName} ${formData.lastName || "Nombre del estudiante"}`}
+                        badgeText="Activo"
+                        badgeClassName="bg-accent-300 text-accent-800 hover:bg-accent-400 border-accent-500"
+                        fields={[
+                            { label: "Paralelo", value: formData.uuidParallel, fallback: "Sin paralelo" },
+                        ]}
+                    />
+                    <Card>
+                        <CardHeader className="pb-3">
+                            <CardTitle>Guía de Mejores Prácticas</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <GuidelinesList
+                                items={[
+                                    { text: "Verifique que los datos sean correctos" },
+                                    { text: "Asegúrese de ingresar un paralelo válido" },
+                                    { text: "No deje campos obligatorios vacíos", variant: "danger", icon: <AlertCircle className="h-4 w-4 text-destructive" /> },
+                                ]}
+                            />
+                        </CardContent>
+                    </Card>
+                </>
+            }
+        />
+    );
+};
+

--- a/src/academic/presentation/ui/Student/List/StudentListContainer.tsx
+++ b/src/academic/presentation/ui/Student/List/StudentListContainer.tsx
@@ -1,0 +1,51 @@
+import { ListStudentsCommand, ListStudentsUseCase } from "@/academic/application/usecases/student/ListStudentsUseCase";
+import { StudentListPresenter } from "./StudentListPresenter";
+import { useInjection } from "inversify-react";
+import { STUDENT_SYMBOLS } from "@/academic/domain/symbols/Student";
+import { useCallback, useEffect, useState } from "react";
+import { Student } from "@/academic/domain/entities/Student";
+
+export const StudentListContainer = () => {
+    const listUseCase = useInjection<ListStudentsUseCase>(STUDENT_SYMBOLS.LIST_USE_CASE);
+
+    const [students, setStudents] = useState<Student[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [searchTerm, setSearchTerm] = useState("");
+
+    const fetchStudents = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        const res = await listUseCase.execute(new ListStudentsCommand(1, 10));
+        res.ifRight(data => {
+            setStudents(data ?? []);
+        }).ifLeft(failures => {
+            setError(failures.map(f => f.message).join(", "));
+        });
+        setLoading(false);
+    }, [listUseCase]);
+
+    useEffect(() => {
+        fetchStudents();
+    }, [fetchStudents]);
+
+    const handleSearchChange = (term: string) => {
+        setSearchTerm(term);
+    };
+
+    const filteredStudents = students.filter(s =>
+        `${s.firstName} ${s.lastName}`.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    return (
+        <StudentListPresenter
+            students={filteredStudents}
+            loading={loading}
+            error={error}
+            onAddStudent={() => { }}
+            onSearchChange={handleSearchChange}
+            searchTerm={searchTerm}
+        />
+    );
+};
+

--- a/src/academic/presentation/ui/Student/List/StudentListPresenter.tsx
+++ b/src/academic/presentation/ui/Student/List/StudentListPresenter.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Search, Plus } from "lucide-react";
+import { Student } from "@/academic/domain/entities/Student";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface StudentListPresenterProps {
+    students: Student[];
+    loading: boolean;
+    error: string | null;
+    searchTerm: string;
+    onSearchChange: (term: string) => void;
+    onAddStudent: () => void;
+}
+
+export function StudentListPresenter({
+    students,
+    loading,
+    error,
+    searchTerm,
+    onSearchChange,
+    onAddStudent,
+}: StudentListPresenterProps) {
+    return (
+        <div className="space-y-6">
+            <Card>
+                <CardHeader>
+                    <div className="flex items-center justify-between">
+                        <CardTitle className="text-2xl font-bold">Estudiantes</CardTitle>
+                        <Button onClick={onAddStudent} className="flex items-center gap-2">
+                            <Plus className="h-4 w-4" />
+                            Agregar Estudiante
+                        </Button>
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    <div className="flex items-center gap-2 mb-6">
+                        <Search className="h-4 w-4 text-muted-foreground" />
+                        <Input
+                            placeholder="Buscar estudiantes..."
+                            value={searchTerm}
+                            onChange={(e) => onSearchChange(e.target.value)}
+                            className="max-w-sm"
+                        />
+                    </div>
+
+                    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                        {loading && <Skeleton className="h-24 w-full col-span-full" />}
+                        {error && (
+                            <div className="text-destructive text-center col-span-full">{error}</div>
+                        )}
+                        {students.map((student) => (
+                            <Card key={student.id} className="hover:shadow-md transition-shadow">
+                                <CardContent className="p-4">
+                                    <div className="flex items-start gap-3">
+                                        <Avatar className="h-12 w-12">
+                                            <AvatarImage
+                                                src="/placeholder.svg"
+                                                alt={`${student.firstName} ${student.lastName}`}
+                                            />
+                                            <AvatarFallback>
+                                                {student.firstName[0]}
+                                                {student.lastName[0]}
+                                            </AvatarFallback>
+                                        </Avatar>
+                                        <div className="flex-1 min-w-0">
+                                            <h3 className="font-semibold text-sm truncate">
+                                                {student.firstName} {student.lastName}
+                                            </h3>
+                                            <p className="text-xs text-muted-foreground mt-1">
+                                                Paralelo: {student.uuidParallel}
+                                            </p>
+                                        </div>
+                                    </div>
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
+
+                    {students.length === 0 && !loading && !error && (
+                        <div className="text-center py-8 text-muted-foreground">
+                            No se encontraron estudiantes
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+

--- a/src/academic/presentation/ui/TeacherAssignment/Create/TeacherAssignmentCreateContainer.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/Create/TeacherAssignmentCreateContainer.tsx
@@ -1,0 +1,31 @@
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { TEACHER_ASSIGNMENT_SYMBOLS } from "@/academic/domain/symbols/TeacherAssignment";
+import { CreateTeacherAssignmentCommand, CreateTeacherAssignmentUseCase } from "@/academic/application/usecases/teacher-assignment/CreateTeacherAssignmentUseCase";
+import { toast } from "@/hooks/use-toast";
+import { TeacherAssignmentCreatePresenter } from "./TeacherAssignmentCreatePresenter";
+
+export const TeacherAssignmentCreateContainer = () => {
+  const createUseCase = useInjection<CreateTeacherAssignmentUseCase>(TEACHER_ASSIGNMENT_SYMBOLS.CREATE_USE_CASE);
+  const { register, handleSubmit, formState: { errors, isSubmitting }, reset } = useForm<CreateTeacherAssignmentCommand>();
+
+  const onSubmit = async (data: CreateTeacherAssignmentCommand) => {
+    const res = await createUseCase.execute(data);
+    res.ifRight(() => {
+      toast({ title: "Asignación creada", description: "La asignación docente ha sido creada", duration: 5000 });
+      reset();
+    }).ifLeft(f => {
+      toast({ title: "Error", description: f.map(x => x.message).join(", "), variant: "destructive", duration: 5000 });
+    });
+  };
+
+  return (
+    <TeacherAssignmentCreatePresenter
+      onCancel={() => {}}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+      loading={isSubmitting}
+    />
+  );
+};

--- a/src/academic/presentation/ui/TeacherAssignment/Create/TeacherAssignmentCreatePresenter.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/Create/TeacherAssignmentCreatePresenter.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { CreateTeacherAssignmentCommand } from "@/academic/application/usecases/teacher-assignment/CreateTeacherAssignmentUseCase";
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<CreateTeacherAssignmentCommand>;
+  errors: FieldErrors<CreateTeacherAssignmentCommand>;
+  loading?: boolean;
+}
+
+export const TeacherAssignmentCreatePresenter = ({ onCancel, handleSubmit, register, errors, loading }: Props) => (
+  <LayoutForm
+    title="Nueva Asignación Docente"
+    description="Registrar asignación de un docente"
+    breadcrumbs={[{ label: "Asignaciones Docentes", href: "/asignaciones-docentes" }, { label: "Nueva" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Registrar Asignación</CardTitle>
+          <CardDescription>Complete los campos para registrar la asignación.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="teacherId">ID Docente *</Label>
+                <Input id="teacherId" type="number" {...register("teacherId", { valueAsNumber: true, required: "Obligatorio" })} />
+                {errors.teacherId && <div className="text-destructive text-sm">{errors.teacherId.message}</div>}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="courseId">ID Curso *</Label>
+                <Input id="courseId" type="number" {...register("courseId", { valueAsNumber: true, required: "Obligatorio" })} />
+                {errors.courseId && <div className="text-destructive text-sm">{errors.courseId.message}</div>}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="subjectId">ID Asignatura *</Label>
+                <Input id="subjectId" type="number" {...register("subjectId", { valueAsNumber: true, required: "Obligatorio" })} />
+                {errors.subjectId && <div className="text-destructive text-sm">{errors.subjectId.message}</div>}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="schoolYearId">Año Lectivo *</Label>
+                <Input id="schoolYearId" {...register("schoolYearId", { required: "Obligatorio" })} />
+                {errors.schoolYearId && <div className="text-destructive text-sm">{errors.schoolYearId.message}</div>}
+              </div>
+            </div>
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Guardando..." : "Guardar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListContainer.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListContainer.tsx
@@ -1,0 +1,37 @@
+import { ListTeacherAssignmentsCommand, ListTeacherAssignmentsUseCase } from "@/academic/application/usecases/teacher-assignment/ListTeacherAssignmentsUseCase";
+import { TeacherAssignmentListPresenter } from "./TeacherAssignmentListPresenter";
+import { TEACHER_ASSIGNMENT_SYMBOLS } from "@/academic/domain/symbols/TeacherAssignment";
+import { useInjection } from "inversify-react";
+import { useCallback, useEffect, useState } from "react";
+import { TeacherAssignment } from "@/academic/domain/entities/TeacherAssignment";
+
+export const TeacherAssignmentListContainer = () => {
+  const listUseCase = useInjection<ListTeacherAssignmentsUseCase>(TEACHER_ASSIGNMENT_SYMBOLS.LIST_USE_CASE);
+  const [assignments, setAssignments] = useState<TeacherAssignment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const res = await listUseCase.execute(new ListTeacherAssignmentsCommand());
+    res.ifRight(data => setAssignments(data ?? [])).ifLeft(f => setError(f.map(x => x.message).join(", ")));
+    setLoading(false);
+  }, [listUseCase]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const filtered = assignments.filter(a => a.teacherId.toString().includes(searchTerm));
+
+  return (
+    <TeacherAssignmentListPresenter
+      assignments={filtered}
+      loading={loading}
+      error={error}
+      searchTerm={searchTerm}
+      onSearchChange={setSearchTerm}
+      onAddAssignment={() => {}}
+    />
+  );
+};

--- a/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListPresenter.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListPresenter.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Search, Plus } from "lucide-react";
+import { TeacherAssignment } from "@/academic/domain/entities/TeacherAssignment";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Props {
+  assignments: TeacherAssignment[];
+  loading: boolean;
+  error: string | null;
+  searchTerm: string;
+  onSearchChange: (t: string) => void;
+  onAddAssignment: () => void;
+}
+
+export const TeacherAssignmentListPresenter = ({ assignments, loading, error, searchTerm, onSearchChange, onAddAssignment }: Props) => (
+  <div className="space-y-6">
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-2xl font-bold">Asignaciones Docentes</CardTitle>
+          <Button onClick={onAddAssignment} className="flex items-center gap-2"><Plus className="h-4 w-4" /> Nueva</Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2 mb-6">
+          <Search className="h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Buscar por docente" value={searchTerm} onChange={e => onSearchChange(e.target.value)} className="max-w-sm" />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {error && <div className="text-destructive text-center col-span-full">{error}</div>}
+          {assignments.map(a => (
+            <Card key={a.id} className="hover:shadow-md transition-shadow">
+              <CardContent className="p-4">
+                <p className="font-semibold">Docente: {a.teacherId}</p>
+                <p className="text-sm">Curso: {a.courseId}</p>
+                <p className="text-sm">Asignatura: {a.subjectId}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        {assignments.length === 0 && !loading && !error && <div className="text-center py-8 text-muted-foreground">No se encontraron asignaciones</div>}
+      </CardContent>
+    </Card>
+  </div>
+);

--- a/src/academic/presentation/ui/TeacherPlanning/Create/TeacherPlanningCreateContainer.tsx
+++ b/src/academic/presentation/ui/TeacherPlanning/Create/TeacherPlanningCreateContainer.tsx
@@ -1,0 +1,31 @@
+import { useForm } from "react-hook-form";
+import { useInjection } from "inversify-react";
+import { TEACHER_PLANNING_SYMBOLS } from "@/academic/domain/symbols/TeacherPlanning";
+import { CreateTeacherPlanningCommand, CreateTeacherPlanningUseCase } from "@/academic/application/usecases/teacher-planning/CreateTeacherPlanningUseCase";
+import { toast } from "@/hooks/use-toast";
+import { TeacherPlanningCreatePresenter } from "./TeacherPlanningCreatePresenter";
+
+export const TeacherPlanningCreateContainer = () => {
+  const createUseCase = useInjection<CreateTeacherPlanningUseCase>(TEACHER_PLANNING_SYMBOLS.CREATE_USE_CASE);
+  const { register, handleSubmit, formState: { errors, isSubmitting }, reset } = useForm<CreateTeacherPlanningCommand>();
+
+  const onSubmit = async (data: CreateTeacherPlanningCommand) => {
+    const res = await createUseCase.execute(data);
+    res.ifRight(() => {
+      toast({ title: "Planificación creada", description: "La planificación ha sido registrada", duration: 5000 });
+      reset();
+    }).ifLeft(f => {
+      toast({ title: "Error", description: f.map(x => x.message).join(", "), variant: "destructive", duration: 5000 });
+    });
+  };
+
+  return (
+    <TeacherPlanningCreatePresenter
+      onCancel={() => {}}
+      handleSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+      loading={isSubmitting}
+    />
+  );
+};

--- a/src/academic/presentation/ui/TeacherPlanning/Create/TeacherPlanningCreatePresenter.tsx
+++ b/src/academic/presentation/ui/TeacherPlanning/Create/TeacherPlanningCreatePresenter.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { CreateTeacherPlanningCommand } from "@/academic/application/usecases/teacher-planning/CreateTeacherPlanningUseCase";
+import { LayoutForm } from "@/components/layout-form";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+  handleSubmit: React.FormEventHandler<HTMLFormElement>;
+  register: UseFormRegister<CreateTeacherPlanningCommand>;
+  errors: FieldErrors<CreateTeacherPlanningCommand>;
+  loading?: boolean;
+}
+
+export const TeacherPlanningCreatePresenter = ({ onCancel, handleSubmit, register, errors, loading }: Props) => (
+  <LayoutForm
+    title="Nueva Planificación"
+    description="Registrar una planificación docente"
+    breadcrumbs={[{ label: "Planificaciones", href: "/planificaciones-docentes" }, { label: "Nueva" }]}
+    sidebar={null}
+    main={
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle>Registrar Planificación</CardTitle>
+          <CardDescription>Complete los campos para registrar la planificación.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="teacherId">ID Docente *</Label>
+                <Input id="teacherId" type="number" {...register("teacherId", { valueAsNumber: true, required: "Obligatorio" })} />
+                {errors.teacherId && <div className="text-destructive text-sm">{errors.teacherId.message}</div>}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="subjectId">ID Asignatura *</Label>
+                <Input id="subjectId" type="number" {...register("subjectId", { valueAsNumber: true, required: "Obligatorio" })} />
+                {errors.subjectId && <div className="text-destructive text-sm">{errors.subjectId.message}</div>}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="courseId">ID Curso *</Label>
+                <Input id="courseId" type="number" {...register("courseId", { valueAsNumber: true, required: "Obligatorio" })} />
+                {errors.courseId && <div className="text-destructive text-sm">{errors.courseId.message}</div>}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="schoolYearId">Año Lectivo *</Label>
+                <Input id="schoolYearId" {...register("schoolYearId", { required: "Obligatorio" })} />
+                {errors.schoolYearId && <div className="text-destructive text-sm">{errors.schoolYearId.message}</div>}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="topic">Tema *</Label>
+                <Input id="topic" {...register("topic", { required: "Obligatorio" })} />
+                {errors.topic && <div className="text-destructive text-sm">{errors.topic.message}</div>}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="description">Descripción *</Label>
+                <Input id="description" {...register("description", { required: "Obligatorio" })} />
+                {errors.description && <div className="text-destructive text-sm">{errors.description.message}</div>}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="week">Semana *</Label>
+                <Input id="week" type="number" {...register("week", { valueAsNumber: true, required: "Obligatorio" })} />
+                {errors.week && <div className="text-destructive text-sm">{errors.week.message}</div>}
+              </div>
+            </div>
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" disabled={loading} className="flex-1">{loading ? "Guardando..." : "Guardar"}</Button>
+              <Button type="button" variant="outline" onClick={onCancel} className="flex-1 bg-transparent">Cancelar</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    }
+  />
+);

--- a/src/academic/presentation/ui/TeacherPlanning/List/TeacherPlanningListContainer.tsx
+++ b/src/academic/presentation/ui/TeacherPlanning/List/TeacherPlanningListContainer.tsx
@@ -1,0 +1,37 @@
+import { ListTeacherPlanningsCommand, ListTeacherPlanningsUseCase } from "@/academic/application/usecases/teacher-planning/ListTeacherPlanningsUseCase";
+import { TeacherPlanningListPresenter } from "./TeacherPlanningListPresenter";
+import { TEACHER_PLANNING_SYMBOLS } from "@/academic/domain/symbols/TeacherPlanning";
+import { useInjection } from "inversify-react";
+import { useCallback, useEffect, useState } from "react";
+import { TeacherPlanning } from "@/academic/domain/entities/TeacherPlanning";
+
+export const TeacherPlanningListContainer = () => {
+  const listUseCase = useInjection<ListTeacherPlanningsUseCase>(TEACHER_PLANNING_SYMBOLS.LIST_USE_CASE);
+  const [plannings, setPlannings] = useState<TeacherPlanning[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const res = await listUseCase.execute(new ListTeacherPlanningsCommand());
+    res.ifRight(data => setPlannings(data ?? [])).ifLeft(f => setError(f.map(x => x.message).join(", ")));
+    setLoading(false);
+  }, [listUseCase]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const filtered = plannings.filter(p => p.topic.toLowerCase().includes(searchTerm.toLowerCase()));
+
+  return (
+    <TeacherPlanningListPresenter
+      plannings={filtered}
+      loading={loading}
+      error={error}
+      searchTerm={searchTerm}
+      onSearchChange={setSearchTerm}
+      onAddPlanning={() => {}}
+    />
+  );
+};

--- a/src/academic/presentation/ui/TeacherPlanning/List/TeacherPlanningListPresenter.tsx
+++ b/src/academic/presentation/ui/TeacherPlanning/List/TeacherPlanningListPresenter.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Search, Plus } from "lucide-react";
+import { TeacherPlanning } from "@/academic/domain/entities/TeacherPlanning";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Props {
+  plannings: TeacherPlanning[];
+  loading: boolean;
+  error: string | null;
+  searchTerm: string;
+  onSearchChange: (t: string) => void;
+  onAddPlanning: () => void;
+}
+
+export const TeacherPlanningListPresenter = ({ plannings, loading, error, searchTerm, onSearchChange, onAddPlanning }: Props) => (
+  <div className="space-y-6">
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-2xl font-bold">Planificaciones</CardTitle>
+          <Button onClick={onAddPlanning} className="flex items-center gap-2"><Plus className="h-4 w-4" /> Nueva</Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2 mb-6">
+          <Search className="h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Buscar por tema" value={searchTerm} onChange={e => onSearchChange(e.target.value)} className="max-w-sm" />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {error && <div className="text-destructive text-center col-span-full">{error}</div>}
+          {plannings.map(p => (
+            <Card key={p.id} className="hover:shadow-md transition-shadow">
+              <CardContent className="p-4">
+                <p className="font-semibold">{p.topic}</p>
+                <p className="text-sm">Curso: {p.courseId}</p>
+                <p className="text-sm">Semana: {p.week}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        {plannings.length === 0 && !loading && !error && <div className="text-center py-8 text-muted-foreground">No se encontraron planificaciones</div>}
+      </CardContent>
+    </Card>
+  </div>
+);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,20 +4,198 @@ import {
 import { TeacherListContainer } from "./academic/presentation/ui/Teacher/List/TeacherListContainer";
 import { TeacherCreateContainer } from "./academic/presentation/ui/Teacher/Create/TeacherCreateContainer";
 import { TeacherEditContainer } from "./academic/presentation/ui/Teacher/Edit/TeacherEditContainer";
+import { StudentListContainer } from "./academic/presentation/ui/Student/List/StudentListContainer";
+import { StudentCreateContainer } from "./academic/presentation/ui/Student/Create/StudentCreateContainer";
+import { StudentEditContainer } from "./academic/presentation/ui/Student/Edit/StudentEditContainer";
+import { RepresentativeListContainer } from "./academic/presentation/ui/Representative/List/RepresentativeListContainer";
+import { RepresentativeCreateContainer } from "./academic/presentation/ui/Representative/Create/RepresentativeCreateContainer";
+import { RepresentativeEditContainer } from "./academic/presentation/ui/Representative/Edit/RepresentativeEditContainer";
+import { AttendanceListContainer } from "./academic/presentation/ui/Attendance/List/AttendanceListContainer";
+import { AttendanceCreateContainer } from "./academic/presentation/ui/Attendance/Create/AttendanceCreateContainer";
+import { AttendanceEditContainer } from "./academic/presentation/ui/Attendance/Edit/AttendanceEditContainer";
+import { EnrollmentListContainer } from "./academic/presentation/ui/Enrollment/List/EnrollmentListContainer";
+import { EnrollmentCreateContainer } from "./academic/presentation/ui/Enrollment/Create/EnrollmentCreateContainer";
+import { EnrollmentEditContainer } from "./academic/presentation/ui/Enrollment/Edit/EnrollmentEditContainer";
+import { BehaviorReportListContainer } from "./academic/presentation/ui/BehaviorReport/List/BehaviorReportListContainer";
+import { BehaviorReportCreateContainer } from "./academic/presentation/ui/BehaviorReport/Create/BehaviorReportCreateContainer";
+import { BehaviorReportEditContainer } from "./academic/presentation/ui/BehaviorReport/Edit/BehaviorReportEditContainer";
+import { AssessmentListContainer } from "./academic/presentation/ui/Assessment/List/AssessmentListContainer";
+import { AssessmentCreateContainer } from "./academic/presentation/ui/Assessment/Create/AssessmentCreateContainer";
+import { AssessmentEditContainer } from "./academic/presentation/ui/Assessment/Edit/AssessmentEditContainer";
+import { MeetingListContainer } from "./academic/presentation/ui/Meeting/List/MeetingListContainer";
+import { MeetingCreateContainer } from "./academic/presentation/ui/Meeting/Create/MeetingCreateContainer";
+import { MeetingEditContainer } from "./academic/presentation/ui/Meeting/Edit/MeetingEditContainer";
+import { PromotionActListContainer } from "./academic/presentation/ui/PromotionAct/List/PromotionActListContainer";
+import { PromotionActCreateContainer } from "./academic/presentation/ui/PromotionAct/Create/PromotionActCreateContainer";
+import { TeacherAssignmentListContainer } from "./academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListContainer";
+import { TeacherAssignmentCreateContainer } from "./academic/presentation/ui/TeacherAssignment/Create/TeacherAssignmentCreateContainer";
+import { TeacherPlanningListContainer } from "./academic/presentation/ui/TeacherPlanning/List/TeacherPlanningListContainer";
+import { TeacherPlanningCreateContainer } from "./academic/presentation/ui/TeacherPlanning/Create/TeacherPlanningCreateContainer";
+import { AcademicHistoryViewContainer } from "./academic/presentation/ui/AcademicHistory/View/AcademicHistoryViewContainer";
+import { OfficialRecordViewContainer } from "./academic/presentation/ui/OfficialRecord/View/OfficialRecordViewContainer";
+import { ReportCardViewContainer } from "./academic/presentation/ui/ReportCard/View/ReportCardViewContainer";
+import { PromotionPromoteContainer } from "./academic/presentation/ui/Promotion/Promote/PromotionPromoteContainer";
+import { AttendanceStatisticsContainer } from "./academic/presentation/ui/Statistics/Attendance/AttendanceStatisticsContainer";
+import { PerformanceStatisticsContainer } from "./academic/presentation/ui/Statistics/Performance/PerformanceStatisticsContainer";
+import { FinalGradeContainer } from "./academic/presentation/ui/Grading/FinalGradeContainer";
+import { ExportReportCardContainer } from "./academic/presentation/ui/Exports/ReportCard/ExportReportCardContainer";
+import { ExportStatisticsContainer } from "./academic/presentation/ui/Exports/Statistics/ExportStatisticsContainer";
 
 export const router = createBrowserRouter([
     {
         path: "/docentes",
-        Component: TeacherListContainer
+        Component: TeacherListContainer,
     },
     {
         path: "/docentes/:id",
-        Component: TeacherEditContainer
+        Component: TeacherEditContainer,
     },
     {
         path: "/docentes/nuevo",
-        Component: TeacherCreateContainer
+        Component: TeacherCreateContainer,
     },
-
+    {
+        path: "/estudiantes",
+        Component: StudentListContainer,
+    },
+    {
+        path: "/estudiantes/:id",
+        Component: StudentEditContainer,
+    },
+    {
+        path: "/estudiantes/nuevo",
+        Component: StudentCreateContainer,
+    },
+    {
+        path: "/representantes",
+        Component: RepresentativeListContainer,
+    },
+    {
+        path: "/representantes/:id",
+        Component: RepresentativeEditContainer,
+    },
+    {
+        path: "/representantes/nuevo",
+        Component: RepresentativeCreateContainer,
+    },
+    {
+        path: "/asistencias",
+        Component: AttendanceListContainer,
+    },
+    {
+        path: "/asistencias/:id",
+        Component: AttendanceEditContainer,
+    },
+    {
+        path: "/asistencias/nuevo",
+        Component: AttendanceCreateContainer,
+    },
+    {
+        path: "/matriculas",
+        Component: EnrollmentListContainer,
+    },
+    {
+        path: "/matriculas/:id",
+        Component: EnrollmentEditContainer,
+    },
+    {
+        path: "/matriculas/nuevo",
+        Component: EnrollmentCreateContainer,
+    },
+    {
+        path: "/reportes-conducta",
+        Component: BehaviorReportListContainer,
+    },
+    {
+        path: "/reportes-conducta/:id",
+        Component: BehaviorReportEditContainer,
+    },
+    {
+        path: "/reportes-conducta/nuevo",
+        Component: BehaviorReportCreateContainer,
+    },
+    {
+        path: "/evaluaciones",
+        Component: AssessmentListContainer,
+    },
+    {
+        path: "/evaluaciones/:id",
+        Component: AssessmentEditContainer,
+    },
+    {
+        path: "/evaluaciones/nuevo",
+        Component: AssessmentCreateContainer,
+    },
+    {
+        path: "/reuniones",
+        Component: MeetingListContainer,
+    },
+    {
+        path: "/reuniones/:id",
+        Component: MeetingEditContainer,
+    },
+    {
+        path: "/reuniones/nuevo",
+        Component: MeetingCreateContainer,
+    },
+    {
+        path: "/actas-promocion",
+        Component: PromotionActListContainer,
+    },
+    {
+        path: "/actas-promocion/nuevo",
+        Component: PromotionActCreateContainer,
+    },
+    {
+        path: "/asignaciones-docentes",
+        Component: TeacherAssignmentListContainer,
+    },
+    {
+        path: "/asignaciones-docentes/nuevo",
+        Component: TeacherAssignmentCreateContainer,
+    },
+    {
+        path: "/planificaciones-docentes",
+        Component: TeacherPlanningListContainer,
+    },
+    {
+        path: "/planificaciones-docentes/nuevo",
+        Component: TeacherPlanningCreateContainer,
+    },
+    {
+        path: "/historial-academico",
+        Component: AcademicHistoryViewContainer,
+    },
+    {
+        path: "/registro-oficial",
+        Component: OfficialRecordViewContainer,
+    },
+    {
+        path: "/boletas",
+        Component: ReportCardViewContainer,
+    },
+    {
+        path: "/promociones",
+        Component: PromotionPromoteContainer,
+    },
+    {
+        path: "/estadisticas/asistencia",
+        Component: AttendanceStatisticsContainer,
+    },
+    {
+        path: "/estadisticas/rendimiento",
+        Component: PerformanceStatisticsContainer,
+    },
+    {
+        path: "/calificaciones/final",
+        Component: FinalGradeContainer,
+    },
+    {
+        path: "/exportaciones/boleta",
+        Component: ExportReportCardContainer,
+    },
+    {
+        path: "/exportaciones/estadisticas",
+        Component: ExportStatisticsContainer,
+    },
 ]);
-


### PR DESCRIPTION
## Summary
- add CRUD views for students and representatives
- wire up behavior reports, assessments, attendance, enrollment, meetings, and promotions
- register routes for academic queries and export workflows
- define use case command type as a broad object

## Testing
- `npm run build`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, react-refresh/only-export-components, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c04ff570dc8330abf4e5fb0e6b3af6