### PR TITLE
test: cover student and teacher assignment screens

### DIFF
--- a/src/academic/application/usecases/representative/ListRepresentativesUseCase.ts
+++ b/src/academic/application/usecases/representative/ListRepresentativesUseCase.ts
@@ -4,6 +4,7 @@ import { Either, Left, Right } from "purify-ts/Either";
 import { AbstractFailure } from "@/academic/domain/entities/failure";
 import { Representative } from "@/academic/domain/entities/Representative";
 import { RepresentativeService } from "@/academic/domain/services/RepresentativeService";
+import { Page } from "@/lib/utils";
 import { REPRESENTATIVE_SYMBOLS } from "@/academic/domain/symbols/Representative";
 
 export class ListRepresentativesCommand implements UseCaseCommand {
@@ -14,13 +15,13 @@ export class ListRepresentativesCommand implements UseCaseCommand {
 }
 
 @injectable()
-export class ListRepresentativesUseCase implements UseCase<Representative[], ListRepresentativesCommand> {
+export class ListRepresentativesUseCase implements UseCase<Page<Representative>, ListRepresentativesCommand> {
     constructor(
         @inject(REPRESENTATIVE_SYMBOLS.SERVICE)
         private service: RepresentativeService
     ) { }
 
-    async execute(command: ListRepresentativesCommand): Promise<Either<AbstractFailure[], Representative[] | undefined>> {
+    async execute(command: ListRepresentativesCommand): Promise<Either<AbstractFailure[], Page<Representative> | undefined>> {
         try {
             const reps = await this.service.list(command.page, command.limit);
             return Right(reps);

--- a/src/academic/application/usecases/student/ListStudentsUseCase.ts
+++ b/src/academic/application/usecases/student/ListStudentsUseCase.ts
@@ -5,6 +5,7 @@ import { AbstractFailure } from "@/academic/domain/entities/failure";
 import { Student } from "@/academic/domain/entities/Student";
 import { StudentService } from "@/academic/domain/services/StudentService";
 import { STUDENT_SYMBOLS } from "@/academic/domain/symbols/Student";
+import { Page } from "@/lib/utils";
 
 export class ListStudentsCommand implements UseCaseCommand {
     constructor(
@@ -15,13 +16,13 @@ export class ListStudentsCommand implements UseCaseCommand {
 }
 
 @injectable()
-export class ListStudentsUseCase implements UseCase<Student[], ListStudentsCommand> {
+export class ListStudentsUseCase implements UseCase<Page<Student>, ListStudentsCommand> {
     constructor(
         @inject(STUDENT_SYMBOLS.SERVICE)
         private service: StudentService
     ) { }
 
-    async execute(command: ListStudentsCommand): Promise<Either<AbstractFailure[], Student[] | undefined>> {
+    async execute(command: ListStudentsCommand): Promise<Either<AbstractFailure[], Page<Student> | undefined>> {
         try {
             const students = await this.service.list(command.page, command.limit, command.uuidParallel);
             return Right(students);

--- a/src/academic/domain/interfaces/RepresentativeRepository.ts
+++ b/src/academic/domain/interfaces/RepresentativeRepository.ts
@@ -1,8 +1,9 @@
 import { Representative } from "../entities/Representative";
+import { Page } from "@/lib/utils";
 
 export interface RepresentativeRepository {
     create(rep: Representative): Promise<Representative>;
-    list(page: number, limit: number): Promise<Representative[]>;
+    list(page: number, limit: number): Promise<Page<Representative>>;
     getById(id: number): Promise<Representative | null>;
     update(rep: Representative): Promise<Representative>;
     delete(id: number): Promise<void>;

--- a/src/academic/domain/interfaces/StudentRepository.ts
+++ b/src/academic/domain/interfaces/StudentRepository.ts
@@ -1,8 +1,9 @@
 import { Student } from "../entities/Student";
+import { Page } from "@/lib/utils";
 
 export interface StudentRepository {
     create(student: Student): Promise<Student>;
-    list(page: number, limit: number, uuidParallel?: string): Promise<Student[]>;
+    list(page: number, limit: number, uuidParallel?: string): Promise<Page<Student>>;
     getById(id: number): Promise<Student | null>;
     update(student: Student): Promise<Student>;
     delete(id: number): Promise<void>;

--- a/src/academic/domain/services/RepresentativeService.ts
+++ b/src/academic/domain/services/RepresentativeService.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from "inversify";
 import { Representative } from "../entities/Representative";
 import { RepresentativeRepository } from "../interfaces/RepresentativeRepository";
+import { Page } from "@/lib/utils";
 import { REPRESENTATIVE_SYMBOLS } from "../symbols/Representative";
 
 @injectable()
@@ -14,7 +15,7 @@ export class RepresentativeService {
         return this.repository.create(rep);
     }
 
-    async list(page: number, limit: number): Promise<Representative[]> {
+    async list(page: number, limit: number): Promise<Page<Representative>> {
         return this.repository.list(page, limit);
     }
 

--- a/src/academic/domain/services/StudentService.ts
+++ b/src/academic/domain/services/StudentService.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from "inversify";
 import { Student } from "../entities/Student";
 import { StudentRepository } from "../interfaces/StudentRepository";
+import { Page } from "@/lib/utils";
 import { STUDENT_SYMBOLS } from "../symbols/Student";
 
 @injectable()
@@ -14,7 +15,7 @@ export class StudentService {
         return this.repository.create(student);
     }
 
-    async list(page: number, limit: number, uuidParallel?: string): Promise<Student[]> {
+    async list(page: number, limit: number, uuidParallel?: string): Promise<Page<Student>> {
         return this.repository.list(page, limit, uuidParallel);
     }
 

--- a/src/academic/infrastructure/api/RepresentativeRepositoryImpl.ts
+++ b/src/academic/infrastructure/api/RepresentativeRepositoryImpl.ts
@@ -3,6 +3,7 @@ import { RepresentativeRepository } from "@/academic/domain/interfaces/Represent
 import { ApiInstance } from "./Api";
 import { RepresentativeOutputDto } from "./dto/RepresentativeDto";
 import { RepresentativeMapper } from "./mappers/RepresentativeMapper";
+import { Page } from "@/lib/utils";
 
 export class RepresentativeRepositoryImpl implements RepresentativeRepository {
     async create(rep: Representative): Promise<Representative> {
@@ -10,12 +11,15 @@ export class RepresentativeRepositoryImpl implements RepresentativeRepository {
         return RepresentativeMapper.toDomain(res.data);
     }
 
-    async list(page: number, limit: number): Promise<Representative[]> {
+    async list(page: number, limit: number): Promise<Page<Representative>> {
         const params = new URLSearchParams();
         params.append("page", page.toString());
         params.append("limit", limit.toString());
-        const res = await ApiInstance.get<RepresentativeOutputDto[]>("/representative", { params });
-        return res.data.map(RepresentativeMapper.toDomain);
+        const res = await ApiInstance.get<Page<RepresentativeOutputDto>>("/representative", { params });
+        return {
+            ...res.data,
+            content: res.data.content.map(RepresentativeMapper.toDomain),
+        };
     }
 
     async getById(id: number): Promise<Representative | null> {

--- a/src/academic/infrastructure/api/StudentRepositoryImpl.ts
+++ b/src/academic/infrastructure/api/StudentRepositoryImpl.ts
@@ -3,6 +3,7 @@ import { Student } from "@/academic/domain/entities/Student";
 import { ApiInstance } from "./Api";
 import { StudentOutputDto } from "./dto/StudentDto";
 import { StudentMapper } from "./mappers/StudentMapper";
+import { Page } from "@/lib/utils";
 
 export class StudentRepositoryImpl implements StudentRepository {
     async create(student: Student): Promise<Student> {
@@ -13,16 +14,19 @@ export class StudentRepositoryImpl implements StudentRepository {
         return StudentMapper.toDomain(res.data);
     }
 
-    async list(page: number, limit: number, uuidParallel?: string): Promise<Student[]> {
+    async list(page: number, limit: number, uuidParallel?: string): Promise<Page<Student>> {
         const params = new URLSearchParams();
         params.append('page', page.toString());
         params.append('limit', limit.toString());
         if (uuidParallel) params.append('uuidParallel', uuidParallel);
-        const res = await ApiInstance.get<StudentOutputDto[]>(
+        const res = await ApiInstance.get<Page<StudentOutputDto>>(
             '/students',
             { params }
         );
-        return res.data.map(StudentMapper.toDomain);
+        return {
+            ...res.data,
+            content: res.data.content.map(StudentMapper.toDomain)
+        };
     }
 
     async getById(id: number): Promise<Student | null> {

--- a/src/academic/presentation/ui/Representative/Create/RepresentativeCreateContainer.test.tsx
+++ b/src/academic/presentation/ui/Representative/Create/RepresentativeCreateContainer.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import { RepresentativeCreateContainer } from "./RepresentativeCreateContainer";
+import { useInjectionMock, mockLeft } from "@/setupTests";
+import { REPRESENTATIVE_SYMBOLS } from "@/academic/domain/symbols/Representative";
+import { CreateRepresentativeUseCase } from "@/academic/application/usecases/representative/CreateRepresentativeUseCase";
+import { toast } from "@/hooks/use-toast";
+
+describe("RepresentativeCreateContainer", () => {
+  let executeMock: CreateRepresentativeUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executeMock = { execute: vi.fn() } as unknown as CreateRepresentativeUseCase;
+    useInjectionMock.mockImplementation((symbol) => {
+      if (symbol === REPRESENTATIVE_SYMBOLS.CREATE_USE_CASE) return executeMock;
+      return null;
+    });
+  });
+
+  it("crea representante y muestra toast de éxito", async () => {
+    executeMock = {
+      execute: vi.fn().mockResolvedValue({
+        ifRight: (fn: (data: { firstName: string; lastName: string }) => void) => {
+          fn({ firstName: "Juan", lastName: "Pérez" });
+          return { ifLeft: () => {} };
+        },
+      }),
+    } as unknown as CreateRepresentativeUseCase;
+
+    render(
+      <MemoryRouter>
+        <RepresentativeCreateContainer />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText(/Nombre/i), { target: { value: "Juan" } });
+    fireEvent.change(screen.getByLabelText(/Apellido/i), { target: { value: "Pérez" } });
+
+    fireEvent.click(screen.getByText("Guardar"));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Representante creado",
+          description: expect.stringContaining("Juan Pérez"),
+        })
+      );
+    });
+  });
+
+  it("muestra error si falla la creación", async () => {
+    executeMock = {
+      execute: vi.fn().mockResolvedValue(
+        mockLeft([{ message: "Error al crear representante", code: "E", field: "root" }])
+      ),
+    } as unknown as CreateRepresentativeUseCase;
+
+    render(
+      <MemoryRouter>
+        <RepresentativeCreateContainer />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText(/Nombre/i), { target: { value: "Juan" } });
+    fireEvent.change(screen.getByLabelText(/Apellido/i), { target: { value: "Pérez" } });
+
+    fireEvent.click(screen.getByText("Guardar"));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Error",
+          description: expect.stringContaining("Error al crear representante"),
+          variant: "destructive",
+        })
+      );
+    });
+  });
+});

--- a/src/academic/presentation/ui/Representative/Create/RepresentativeCreateContainer.tsx
+++ b/src/academic/presentation/ui/Representative/Create/RepresentativeCreateContainer.tsx
@@ -8,7 +8,7 @@ import { toast } from "@/hooks/use-toast";
 export const RepresentativeCreateContainer = () => {
     const createUseCase = useInjection<CreateRepresentativeUseCase>(REPRESENTATIVE_SYMBOLS.CREATE_USE_CASE);
 
-    const { register, handleSubmit, watch, formState: { isSubmitting } } = useForm<CreateRepresentativeCommand>({
+    const { register, handleSubmit, watch, formState: { errors, isSubmitting } } = useForm<CreateRepresentativeCommand>({
         defaultValues: {
             firstName: "",
             lastName: "",
@@ -54,6 +54,7 @@ export const RepresentativeCreateContainer = () => {
             onCancel={onCancel}
             handleSubmit={handleSubmit(onSubmit)}
             register={register}
+            errors={errors}
             loading={isSubmitting}
             formData={formData}
         />

--- a/src/academic/presentation/ui/Representative/Create/RepresentativeCreatePresenter.test.tsx
+++ b/src/academic/presentation/ui/Representative/Create/RepresentativeCreatePresenter.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import { useForm } from "react-hook-form";
+import { CreateRepresentativeCommand } from "@/academic/application/usecases/representative/CreateRepresentativeUseCase";
+import { RepresentativeCreatePresenter } from "./RepresentativeCreatePresenter";
+
+function Wrapper({
+  formData,
+  onCancel,
+  loading,
+  _handleSubmit,
+}: Readonly<{
+  formData: CreateRepresentativeCommand;
+  onCancel: () => void;
+  loading?: boolean;
+  _handleSubmit: (data: CreateRepresentativeCommand) => void;
+}>) {
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<CreateRepresentativeCommand>({
+    defaultValues: { ...formData },
+  });
+
+  return (
+    <MemoryRouter>
+      <RepresentativeCreatePresenter
+        onCancel={onCancel}
+        loading={loading}
+        handleSubmit={handleSubmit(_handleSubmit)}
+        register={register}
+        errors={errors}
+        formData={formData}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe("RepresentativeCreatePresenter", () => {
+  it("renderiza el título y botones", () => {
+    render(
+      <Wrapper
+        formData={new CreateRepresentativeCommand("", "")}
+        onCancel={vi.fn()}
+        _handleSubmit={vi.fn()}
+        loading={false}
+      />
+    );
+
+    expect(screen.getByText("Registrar Representante")).toBeInTheDocument();
+    expect(screen.getByText("Guardar")).toBeInTheDocument();
+    expect(screen.getByText("Cancelar")).toBeInTheDocument();
+  });
+
+  it("muestra errores de validación", async () => {
+    render(
+      <Wrapper
+        formData={new CreateRepresentativeCommand("", "")}
+        onCancel={vi.fn()}
+        _handleSubmit={vi.fn()}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByText("Guardar"));
+    expect(await screen.findByText("El nombre es obligatorio")).toBeInTheDocument();
+    expect(await screen.findByText("El apellido es obligatorio")).toBeInTheDocument();
+  });
+
+  it("llama a onCancel al hacer clic en Cancelar", () => {
+    const onCancel = vi.fn();
+    render(
+      <Wrapper
+        formData={new CreateRepresentativeCommand("", "")}
+        onCancel={onCancel}
+        _handleSubmit={vi.fn()}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByText("Cancelar"));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("deshabilita el botón Guardar cuando loading es true", () => {
+    render(
+      <Wrapper
+        formData={new CreateRepresentativeCommand("", "")}
+        onCancel={vi.fn()}
+        _handleSubmit={vi.fn()}
+        loading={true}
+      />
+    );
+    expect(screen.getByText("Guardando...")).toBeDisabled();
+  });
+});

--- a/src/academic/presentation/ui/Representative/Create/RepresentativeCreatePresenter.tsx
+++ b/src/academic/presentation/ui/Representative/Create/RepresentativeCreatePresenter.tsx
@@ -7,12 +7,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AlertCircle, ShieldCheck } from "lucide-react";
-import { UseFormRegister } from "react-hook-form";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
 
 interface RepresentativeCreatePresenterProps {
     onCancel: () => void;
     handleSubmit: React.FormEventHandler<HTMLFormElement>;
     register: UseFormRegister<CreateRepresentativeCommand>;
+    errors: FieldErrors<CreateRepresentativeCommand>;
     loading?: boolean;
     formData: CreateRepresentativeCommand;
 }
@@ -21,6 +22,7 @@ export const RepresentativeCreatePresenter = ({
     onCancel,
     handleSubmit,
     register,
+    errors,
     loading,
     formData,
 }: RepresentativeCreatePresenterProps) => {
@@ -50,6 +52,9 @@ export const RepresentativeCreatePresenter = ({
                                             id="firstName"
                                             {...register("firstName", { required: "El nombre es obligatorio" })}
                                         />
+                                        {errors.firstName && (
+                                            <div className="text-destructive text-sm">{errors.firstName.message}</div>
+                                        )}
                                     </div>
                                     <div className="space-y-2">
                                         <Label htmlFor="lastName">Apellido *</Label>
@@ -57,6 +62,9 @@ export const RepresentativeCreatePresenter = ({
                                             id="lastName"
                                             {...register("lastName", { required: "El apellido es obligatorio" })}
                                         />
+                                        {errors.lastName && (
+                                            <div className="text-destructive text-sm">{errors.lastName.message}</div>
+                                        )}
                                     </div>
                                     <div className="space-y-2">
                                         <Label htmlFor="identification">Identificación</Label>

--- a/src/academic/presentation/ui/Representative/Edit/RepresentativeEditContainer.test.tsx
+++ b/src/academic/presentation/ui/Representative/Edit/RepresentativeEditContainer.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, Mock } from "vitest";
+import { MemoryRouter } from "react-router";
+import { RepresentativeEditContainer } from "./RepresentativeEditContainer";
+import { UpdateRepresentativeUseCase } from "@/academic/application/usecases/representative/UpdateRepresentativeUseCase";
+import { GetRepresentativeUseCase } from "@/academic/application/usecases/representative/GetRepresentativeUseCase";
+import { useInjectionMock, mockLeft, mockRight } from "@/setupTests";
+import { REPRESENTATIVE_SYMBOLS } from "@/academic/domain/symbols/Representative";
+import userEvent from "@testing-library/user-event";
+import { toast } from "@/hooks/use-toast";
+import { useParams } from "react-router";
+import { AbstractFailure } from "@/academic/domain/entities/failure";
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof import("react-router")>("react-router");
+  return {
+    ...actual,
+    useParams: vi.fn(),
+  };
+});
+
+function provideMocks({ get, update }: { get: GetRepresentativeUseCase; update: UpdateRepresentativeUseCase }) {
+  useInjectionMock.mockImplementation((symbol) => {
+    if (symbol === REPRESENTATIVE_SYMBOLS.GET_USE_CASE) return get;
+    if (symbol === REPRESENTATIVE_SYMBOLS.UPDATE_USE_CASE) return update;
+    return null;
+  });
+}
+
+describe("RepresentativeEditContainer", () => {
+  const getUseCase = {
+    execute: vi.fn().mockResolvedValue(
+      mockRight({ id: 1, firstName: "Juan", lastName: "Pérez" })
+    ),
+  } as unknown as GetRepresentativeUseCase;
+
+  const updateUseCase = {
+    execute: vi.fn().mockResolvedValue(
+      mockRight({ id: 1, firstName: "Juan", lastName: "Pérez" })
+    ),
+  } as unknown as UpdateRepresentativeUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provideMocks({ get: getUseCase, update: updateUseCase });
+    (useParams as Mock).mockReturnValue({ id: "1" });
+  });
+
+  it("carga datos del representante al montar", async () => {
+    render(
+      <MemoryRouter>
+        <RepresentativeEditContainer />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(getUseCase.execute).toHaveBeenCalled();
+    });
+
+    expect(await screen.findByDisplayValue("Juan")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Pérez")).toBeInTheDocument();
+  });
+
+  it("ejecuta updateUseCase al enviar el formulario", async () => {
+    render(
+      <MemoryRouter>
+        <RepresentativeEditContainer />
+      </MemoryRouter>
+    );
+
+    const firstNameInput = await screen.findByLabelText(/Nombre/i);
+    await userEvent.clear(firstNameInput);
+    await userEvent.type(firstNameInput, "Pedro");
+
+    const lastNameInput = screen.getByLabelText(/Apellido/i);
+    await userEvent.clear(lastNameInput);
+    await userEvent.type(lastNameInput, "Gómez");
+
+    await userEvent.click(screen.getByText("Guardar"));
+
+    await waitFor(() => {
+      expect(updateUseCase.execute).toHaveBeenCalled();
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Representante actualizado",
+        })
+      );
+    });
+  });
+
+  it("muestra toast de error si getUseCase falla", async () => {
+    getUseCase.execute = vi.fn().mockResolvedValue(
+      mockLeft([new AbstractFailure("error", "Error al obtener representante", "root")])
+    );
+    provideMocks({ get: getUseCase, update: updateUseCase });
+
+    render(
+      <MemoryRouter>
+        <RepresentativeEditContainer />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Error",
+          description: expect.stringContaining("Error al obtener el representante"),
+        })
+      );
+    });
+  });
+});

--- a/src/academic/presentation/ui/Representative/Edit/RepresentativeEditContainer.tsx
+++ b/src/academic/presentation/ui/Representative/Edit/RepresentativeEditContainer.tsx
@@ -14,35 +14,50 @@ export const RepresentativeEditContainer = () => {
     const updateUseCase = useInjection<UpdateRepresentativeUseCase>(REPRESENTATIVE_SYMBOLS.UPDATE_USE_CASE);
     const getUseCase = useInjection<GetRepresentativeUseCase>(REPRESENTATIVE_SYMBOLS.GET_USE_CASE);
 
-    const { handleSubmit, register, watch, setValue, formState: { isSubmitting } } = useForm<UpdateRepresentativeCommand>();
+    const { handleSubmit, register, watch, setValue, formState: { errors, isSubmitting } } = useForm<UpdateRepresentativeCommand>({
+        defaultValues: {
+            id: 0,
+            firstName: "",
+            lastName: "",
+            phone: "",
+            birthDate: "",
+            uuidUser: "",
+            address: "",
+            identification: "",
+            nacionality: "",
+            gender: "",
+            image: "",
+        },
+    });
 
     const formData = watch();
 
     const fetchRepresentative = useCallback(async () => {
         if (!id) return;
         const res = await getUseCase.execute(new GetRepresentativeCommand(Number(id)));
-        res.ifRight((rep) => {
-            if (!rep) return;
-            setValue("id", rep.id);
-            setValue("firstName", rep.firstName);
-            setValue("lastName", rep.lastName);
-            setValue("phone", rep.phone || "");
-            setValue("birthDate", rep.birthDate || "");
-            setValue("uuidUser", rep.uuidUser || "");
-            setValue("address", rep.address || "");
-            setValue("identification", rep.identification || "");
-            setValue("nacionality", rep.nacionality || "");
-            setValue("gender", rep.gender || "");
-            setValue("image", rep.image || "");
-        });
-        res.ifLeft((failures) => {
-            toast({
-                title: "Error",
-                description: "Error al obtener el representante: " + failures.map(f => f.message).join(", "),
-                duration: 5000,
-                variant: "destructive",
+        res
+            .ifRight((rep) => {
+                if (!rep) return;
+                setValue("id", rep.id);
+                setValue("firstName", rep.firstName);
+                setValue("lastName", rep.lastName);
+                setValue("phone", rep.phone || "");
+                setValue("birthDate", rep.birthDate || "");
+                setValue("uuidUser", rep.uuidUser || "");
+                setValue("address", rep.address || "");
+                setValue("identification", rep.identification || "");
+                setValue("nacionality", rep.nacionality || "");
+                setValue("gender", rep.gender || "");
+                setValue("image", rep.image || "");
+            })
+            .ifLeft((failures) => {
+                toast({
+                    title: "Error",
+                    description: "Error al obtener el representante: " + failures.map(f => f.message).join(", "),
+                    duration: 5000,
+                    variant: "destructive",
+                });
             });
-        });
     }, [getUseCase, id, setValue]);
 
     useEffect(() => {
@@ -51,21 +66,22 @@ export const RepresentativeEditContainer = () => {
 
     const onSubmit = async (data: UpdateRepresentativeCommand) => {
         const res = await updateUseCase.execute(data);
-        res.ifRight((rep) => {
-            toast({
-                title: "Representante actualizado",
-                description: `El representante ${rep?.firstName} ${rep?.lastName} ha sido actualizado.`,
-                duration: 5000,
+        res
+            .ifRight((rep) => {
+                toast({
+                    title: "Representante actualizado",
+                    description: `El representante ${rep?.firstName} ${rep?.lastName} ha sido actualizado.`,
+                    duration: 5000,
+                });
+            })
+            .ifLeft((failures) => {
+                toast({
+                    title: "Error",
+                    description: "Error al actualizar el representante: " + failures.map(f => f.message).join(", "),
+                    duration: 5000,
+                    variant: "destructive",
+                });
             });
-        });
-        res.ifLeft((failures) => {
-            toast({
-                title: "Error",
-                description: "Error al actualizar el representante: " + failures.map(f => f.message).join(", "),
-                duration: 5000,
-                variant: "destructive",
-            });
-        });
     };
 
     return (
@@ -73,6 +89,7 @@ export const RepresentativeEditContainer = () => {
             onCancel={() => { }}
             handleSubmit={handleSubmit(onSubmit)}
             register={register}
+            errors={errors}
             loading={isSubmitting}
             formData={formData}
         />

--- a/src/academic/presentation/ui/Representative/Edit/RepresentativeEditPresenter.test.tsx
+++ b/src/academic/presentation/ui/Representative/Edit/RepresentativeEditPresenter.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import { useForm } from "react-hook-form";
+import { UpdateRepresentativeCommand } from "@/academic/application/usecases/representative/UpdateRepresentativeUseCase";
+import { RepresentativeEditPresenter } from "./RepresentativeEditPresenter";
+
+function Wrapper({
+  formData,
+  onCancel,
+  loading,
+  _handleSubmit,
+}: Readonly<{
+  formData: UpdateRepresentativeCommand;
+  onCancel: () => void;
+  loading?: boolean;
+  _handleSubmit: (data: UpdateRepresentativeCommand) => void;
+}>) {
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<UpdateRepresentativeCommand>({
+    defaultValues: { ...formData },
+  });
+
+  return (
+    <MemoryRouter>
+      <RepresentativeEditPresenter
+        onCancel={onCancel}
+        loading={loading}
+        handleSubmit={handleSubmit(_handleSubmit)}
+        register={register}
+        errors={errors}
+        formData={formData}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe("RepresentativeEditPresenter", () => {
+  it("renderiza el título y botones", async () => {
+    render(
+      <Wrapper
+        formData={new UpdateRepresentativeCommand(1, "", "")}
+        onCancel={vi.fn()}
+        _handleSubmit={vi.fn()}
+        loading={false}
+      />
+    );
+    const titles = await screen.findAllByText(/Editar Representante/i);
+    expect(titles.length).toBeGreaterThan(0);
+    expect(screen.getByText("Guardar")).toBeInTheDocument();
+    expect(screen.getByText("Cancelar")).toBeInTheDocument();
+  });
+
+  it("muestra errores de validación", async () => {
+    render(
+      <Wrapper
+        formData={new UpdateRepresentativeCommand(1, "", "")}
+        onCancel={vi.fn()}
+        _handleSubmit={vi.fn()}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByText("Guardar"));
+    expect(await screen.findByText("El nombre es obligatorio")).toBeInTheDocument();
+    expect(await screen.findByText("El apellido es obligatorio")).toBeInTheDocument();
+  });
+
+  it("llama a onCancel al hacer clic en Cancelar", () => {
+    const onCancel = vi.fn();
+    render(
+      <Wrapper
+        formData={new UpdateRepresentativeCommand(1, "", "")}
+        onCancel={onCancel}
+        _handleSubmit={vi.fn()}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByText("Cancelar"));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("deshabilita el botón Guardar cuando loading es true", () => {
+    render(
+      <Wrapper
+        formData={new UpdateRepresentativeCommand(1, "", "")}
+        onCancel={vi.fn()}
+        _handleSubmit={vi.fn()}
+        loading={true}
+      />
+    );
+    expect(screen.getByText("Guardando...")).toBeDisabled();
+  });
+});

--- a/src/academic/presentation/ui/Representative/Edit/RepresentativeEditPresenter.tsx
+++ b/src/academic/presentation/ui/Representative/Edit/RepresentativeEditPresenter.tsx
@@ -7,12 +7,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AlertCircle, ShieldCheck } from "lucide-react";
-import { UseFormRegister } from "react-hook-form";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
 
 interface RepresentativeEditPresenterProps {
     onCancel: () => void;
     handleSubmit: React.FormEventHandler<HTMLFormElement>;
     register: UseFormRegister<UpdateRepresentativeCommand>;
+    errors: FieldErrors<UpdateRepresentativeCommand>;
     loading?: boolean;
     formData: UpdateRepresentativeCommand;
 }
@@ -21,6 +22,7 @@ export const RepresentativeEditPresenter = ({
     onCancel,
     handleSubmit,
     register,
+    errors,
     loading,
     formData,
 }: RepresentativeEditPresenterProps) => {
@@ -50,6 +52,9 @@ export const RepresentativeEditPresenter = ({
                                             id="firstName"
                                             {...register("firstName", { required: "El nombre es obligatorio" })}
                                         />
+                                        {errors.firstName && (
+                                            <div className="text-destructive text-sm">{errors.firstName.message}</div>
+                                        )}
                                     </div>
                                     <div className="space-y-2">
                                         <Label htmlFor="lastName">Apellido *</Label>
@@ -57,6 +62,9 @@ export const RepresentativeEditPresenter = ({
                                             id="lastName"
                                             {...register("lastName", { required: "El apellido es obligatorio" })}
                                         />
+                                        {errors.lastName && (
+                                            <div className="text-destructive text-sm">{errors.lastName.message}</div>
+                                        )}
                                     </div>
                                     <div className="space-y-2">
                                         <Label htmlFor="identification">Identificación</Label>

--- a/src/academic/presentation/ui/Representative/List/RepresentativeListContainer.test.tsx
+++ b/src/academic/presentation/ui/Representative/List/RepresentativeListContainer.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router";
+import { useInjectionMock, mockLeft, mockRight } from "@/setupTests";
+import { REPRESENTATIVE_SYMBOLS } from "@/academic/domain/symbols/Representative";
+import { ListRepresentativesUseCase } from "@/academic/application/usecases/representative/ListRepresentativesUseCase";
+import { RepresentativeListContainer } from "./RepresentativeListContainer";
+import { Page } from "@/lib/utils";
+import { toast } from "@/hooks/use-toast";
+
+describe("RepresentativeListContainer", () => {
+  let listUseCase: ListRepresentativesUseCase = {
+    execute: vi.fn().mockResolvedValue(
+      mockRight({ content: [], page: 1, size: 10, total: 0, totalPage: 0 })
+    ),
+  } as unknown as ListRepresentativesUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useInjectionMock.mockImplementation((symbol) => {
+      if (symbol === REPRESENTATIVE_SYMBOLS.LIST_USE_CASE) return listUseCase;
+      return null;
+    });
+  });
+
+  it("muestra mensaje de error si la carga falla", async () => {
+    listUseCase = {
+      execute: vi.fn().mockResolvedValue(
+        mockLeft([{ message: "Error de red", code: "NETWORK", field: "root" }])
+      ),
+    } as unknown as ListRepresentativesUseCase;
+
+    render(
+      <MemoryRouter>
+        <RepresentativeListContainer />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Error",
+          description: expect.stringContaining("Error de red"),
+        })
+      );
+    });
+  });
+
+  it("muestra lista de representantes si la carga es exitosa", async () => {
+    listUseCase = {
+      execute: vi.fn().mockResolvedValue(
+        mockRight({
+          content: [
+            { id: 1, firstName: "Juan", lastName: "Pérez" },
+          ],
+          page: 1,
+          size: 10,
+          total: 1,
+          totalPage: 1,
+        } as Page<any>)
+      ),
+    } as unknown as ListRepresentativesUseCase;
+
+    render(
+      <MemoryRouter>
+        <RepresentativeListContainer />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Juan Pérez")).toBeInTheDocument();
+    });
+  });
+
+  it("muestra skeleton mientras carga", async () => {
+    listUseCase = {
+      execute: vi.fn(() => new Promise(() => {})),
+    } as unknown as ListRepresentativesUseCase;
+
+    render(
+      <MemoryRouter>
+        <RepresentativeListContainer />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("status")).toBeInTheDocument();
+  });
+});

--- a/src/academic/presentation/ui/Representative/List/RepresentativeListPresenter.test.tsx
+++ b/src/academic/presentation/ui/Representative/List/RepresentativeListPresenter.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import { RepresentativeListPresenter } from "./RepresentativeListPresenter";
+import { Representative } from "@/academic/domain/entities/Representative";
+import { Page } from "@/lib/utils";
+
+const defaultProps = {
+  representatives: {
+    content: [] as Representative[],
+    page: 1,
+    size: 10,
+    total: 0,
+    totalPage: 0,
+  } as Page<Representative>,
+  loading: false,
+  error: null as string | null,
+  searchTerm: "",
+  onSearchChange: vi.fn(),
+  onAddRepresentative: vi.fn(),
+};
+
+const renderPresenter = (
+  props: Partial<React.ComponentProps<typeof RepresentativeListPresenter>> = {}
+) => {
+  return render(
+    <MemoryRouter>
+      <RepresentativeListPresenter {...defaultProps} {...props} />
+    </MemoryRouter>
+  );
+};
+
+describe("RepresentativeListPresenter", () => {
+  it("muestra skeleton mientras carga", async () => {
+    renderPresenter({ loading: true });
+    expect(await screen.findByRole("status")).toBeInTheDocument();
+  });
+
+  it("muestra mensaje de error", () => {
+    const error = "Error de red";
+    renderPresenter({ error });
+    expect(screen.getByText(error)).toBeInTheDocument();
+  });
+
+  it("muestra representantes", () => {
+    const reps: Page<Representative> = {
+      content: [
+        new Representative(1, "Juan", "Pérez"),
+      ],
+      page: 1,
+      size: 10,
+      total: 1,
+      totalPage: 1,
+    } as any;
+    renderPresenter({ representatives: reps });
+    expect(screen.getByText("Juan Pérez")).toBeInTheDocument();
+  });
+
+  it("muestra mensaje cuando no hay representantes", () => {
+    renderPresenter({ representatives: { ...defaultProps.representatives, content: [] } });
+    expect(screen.getByText("No hay representantes registrados aún.")).toBeInTheDocument();
+  });
+
+  it("muestra controles de paginación", () => {
+    const reps: Page<Representative> = {
+      content: [],
+      page: 1,
+      size: 10,
+      total: 20,
+      totalPage: 2,
+    } as any;
+    renderPresenter({ representatives: reps });
+    expect(
+      screen.getByText("Página 1 de 2 - Total de representantes: 20")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Página anterior")).toBeInTheDocument();
+    expect(screen.getByText("Página siguiente")).toBeInTheDocument();
+  });
+});

--- a/src/academic/presentation/ui/Representative/List/RepresentativeListPresenter.tsx
+++ b/src/academic/presentation/ui/Representative/List/RepresentativeListPresenter.tsx
@@ -4,12 +4,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Search, Plus } from "lucide-react";
+import { Search, Plus, UserX } from "lucide-react";
 import { Representative } from "@/academic/domain/entities/Representative";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Pagination, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Page } from "@/lib/utils";
 
 interface RepresentativeListPresenterProps {
-    representatives: Representative[];
+    representatives: Page<Representative>;
     loading: boolean;
     error: string | null;
     searchTerm: string;
@@ -49,11 +51,11 @@ export function RepresentativeListPresenter({
                     </div>
 
                     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                        {loading && <Skeleton className="h-24 w-full col-span-full" />}
+                        {loading && <Skeleton role="status" className="h-24 w-full col-span-full" />}
                         {error && (
                             <div className="text-destructive text-center col-span-full">{error}</div>
                         )}
-                        {representatives.map((rep) => (
+                {representatives.content.map((rep) => (
                             <Card key={rep.id} className="hover:shadow-md transition-shadow">
                                 <CardContent className="p-4">
                                     <div className="flex items-start gap-3">
@@ -78,11 +80,39 @@ export function RepresentativeListPresenter({
                         ))}
                     </div>
 
-                    {representatives.length === 0 && !loading && !error && (
-                        <div className="text-center py-8 text-muted-foreground">
-                            No se encontraron representantes
+                        {representatives.content.length === 0 && !loading && !error && (
+                        <div className="col-span-3 text-center py-8 text-muted-foreground w-full flex flex-col items-center space-y-4">
+                            <UserX className="h-12 w-12 text-muted-foreground" />
+                            <p className="text-lg font-medium">
+                                {searchTerm
+                                    ? `No encontramos resultados para "${searchTerm}".`
+                                    : "No hay representantes registrados aún."}
+                            </p>
+                            {!searchTerm && (
+                                <Button onClick={onAddRepresentative}>
+                                    Registrar representante
+                                </Button>
+                            )}
                         </div>
                     )}
+
+                    <Pagination className="col-span-full justify-center">
+                        <PaginationPrevious className="bg-background" />
+                        {representatives.total > 1 && Array.from({ length: representatives.totalPage }).map((_, index) => (
+                            <PaginationLink
+                                key={`page-${index + 1}`}
+                                href={`/representantes?page=${index + 1}`}
+                                isActive={index === representatives.page}
+                                className="bg-background"
+                            >
+                                {index + 1}
+                            </PaginationLink>
+                        ))}
+                        <PaginationNext className="bg-background" />
+                    </Pagination>
+                    <div className="col-span-full text-center text-sm text-muted-foreground">
+                        Página {representatives.page} de {representatives.totalPage} - Total de representantes: {representatives.total}
+                    </div>
                 </CardContent>
             </Card>
         </div>

--- a/src/academic/presentation/ui/Student/Create/StudentCreateContainer.test.tsx
+++ b/src/academic/presentation/ui/Student/Create/StudentCreateContainer.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import { StudentCreateContainer } from "./StudentCreateContainer";
+import { useInjectionMock, mockLeft } from "@/setupTests";
+import { STUDENT_SYMBOLS } from "@/academic/domain/symbols/Student";
+import { CreateStudentUseCase } from "@/academic/application/usecases/student/CreateStudentUseCase";
+import { toast } from "@/hooks/use-toast";
+
+describe("StudentCreateContainer", () => {
+  let executeMock: CreateStudentUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executeMock = { execute: vi.fn() } as unknown as CreateStudentUseCase;
+    useInjectionMock.mockImplementation((symbol) => {
+      if (symbol === STUDENT_SYMBOLS.CREATE_USE_CASE) return executeMock;
+      return null;
+    });
+  });
+
+  it("crea estudiante y muestra toast de éxito", async () => {
+    executeMock = {
+      execute: vi.fn().mockResolvedValue({
+        ifRight: (fn: (data: { firstName: string; lastName: string }) => void) => {
+          fn({ firstName: "Juan", lastName: "Pérez" });
+          return { ifLeft: () => {} };
+        },
+      }),
+    } as unknown as CreateStudentUseCase;
+
+    render(
+      <MemoryRouter>
+        <StudentCreateContainer />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText(/Nombre/i), { target: { value: "Juan" } });
+    fireEvent.change(screen.getByLabelText(/Apellido/i), { target: { value: "Pérez" } });
+    fireEvent.change(screen.getByLabelText(/Paralelo/i), { target: { value: "P1" } });
+
+    fireEvent.click(screen.getByText("Guardar"));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Estudiante creado",
+          description: expect.stringContaining("Juan Pérez"),
+        })
+      );
+    });
+  });
+
+  it("muestra error si falla la creación", async () => {
+    executeMock = {
+      execute: vi.fn().mockResolvedValue(
+        mockLeft([{ message: "Error al crear estudiante", code: "E", field: "root" }])
+      ),
+    } as unknown as CreateStudentUseCase;
+
+    render(
+      <MemoryRouter>
+        <StudentCreateContainer />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText(/Nombre/i), { target: { value: "Juan" } });
+    fireEvent.change(screen.getByLabelText(/Apellido/i), { target: { value: "Pérez" } });
+    fireEvent.change(screen.getByLabelText(/Paralelo/i), { target: { value: "P1" } });
+
+    fireEvent.click(screen.getByText("Guardar"));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Error",
+          description: expect.stringContaining("Error al crear estudiante"),
+          variant: "destructive",
+        })
+      );
+    });
+  });
+});
+

--- a/src/academic/presentation/ui/Student/Create/StudentCreatePresenter.test.tsx
+++ b/src/academic/presentation/ui/Student/Create/StudentCreatePresenter.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import { useForm } from "react-hook-form";
+import { CreateStudentCommand } from "@/academic/application/usecases/student/CreateStudentUseCase";
+import { StudentCreatePresenter } from "./StudentCreatePresenter";
+
+function Wrapper({
+  formData,
+  onCancel,
+  loading,
+  _handleSubmit,
+}: Readonly<{
+  formData: CreateStudentCommand;
+  onCancel: () => void;
+  loading?: boolean;
+  _handleSubmit: (data: CreateStudentCommand) => void;
+}>) {
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<CreateStudentCommand>({
+    defaultValues: { ...formData },
+  });
+
+  return (
+    <MemoryRouter>
+      <StudentCreatePresenter
+        onCancel={onCancel}
+        loading={loading}
+        handleSubmit={handleSubmit(_handleSubmit)}
+        register={register}
+        errors={errors}
+        formData={formData}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe("StudentCreatePresenter", () => {
+  it("renderiza el título y botones", () => {
+    render(
+      <Wrapper
+        formData={new CreateStudentCommand("", "", "")}
+        onCancel={vi.fn()}
+        _handleSubmit={vi.fn()}
+        loading={false}
+      />
+    );
+
+    expect(screen.getByText("Registrar Estudiante")).toBeInTheDocument();
+    expect(screen.getByText("Guardar")).toBeInTheDocument();
+    expect(screen.getByText("Cancelar")).toBeInTheDocument();
+  });
+
+  it("muestra errores de validación", async () => {
+    render(
+      <Wrapper
+        formData={new CreateStudentCommand("", "", "")}
+        onCancel={vi.fn()}
+        _handleSubmit={vi.fn()}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByText("Guardar"));
+    expect(await screen.findByText("El nombre es obligatorio")).toBeInTheDocument();
+    expect(await screen.findByText("El apellido es obligatorio")).toBeInTheDocument();
+  });
+
+  it("llama a onCancel al hacer clic en Cancelar", () => {
+    const onCancel = vi.fn();
+    render(
+      <Wrapper
+        formData={new CreateStudentCommand("", "", "")}
+        onCancel={onCancel}
+        _handleSubmit={vi.fn()}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByText("Cancelar"));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("deshabilita el botón Guardar cuando loading es true", () => {
+    render(
+      <Wrapper
+        formData={new CreateStudentCommand("", "", "")}
+        onCancel={vi.fn()}
+        _handleSubmit={vi.fn()}
+        loading={true}
+      />
+    );
+    expect(screen.getByText("Guardando...")).toBeDisabled();
+  });
+});
+

--- a/src/academic/presentation/ui/Student/Create/StudentCreatePresenter.tsx
+++ b/src/academic/presentation/ui/Student/Create/StudentCreatePresenter.tsx
@@ -52,6 +52,9 @@ export const StudentCreatePresenter = ({
                                             id="firstName"
                                             {...register("firstName", { required: "El nombre es obligatorio" })}
                                         />
+                                        {errors.firstName && (
+                                            <div className="text-destructive text-sm">{errors.firstName.message}</div>
+                                        )}
                                     </div>
                                     <div className="space-y-2">
                                         <Label htmlFor="lastName">Apellido *</Label>
@@ -59,6 +62,9 @@ export const StudentCreatePresenter = ({
                                             id="lastName"
                                             {...register("lastName", { required: "El apellido es obligatorio" })}
                                         />
+                                        {errors.lastName && (
+                                            <div className="text-destructive text-sm">{errors.lastName.message}</div>
+                                        )}
                                     </div>
                                     <div className="space-y-2 md:col-span-2">
                                         <Label htmlFor="uuidParallel">Paralelo *</Label>

--- a/src/academic/presentation/ui/Student/Edit/StudentEditContainer.test.tsx
+++ b/src/academic/presentation/ui/Student/Edit/StudentEditContainer.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, Mock } from "vitest";
+import { MemoryRouter } from "react-router";
+import { StudentEditContainer } from "./StudentEditContainer";
+import { UpdateStudentUseCase } from "@/academic/application/usecases/student/UpdateStudentUseCase";
+import { GetStudentUseCase } from "@/academic/application/usecases/student/GetStudentUseCase";
+import { useInjectionMock, mockLeft, mockRight } from "@/setupTests";
+import { STUDENT_SYMBOLS } from "@/academic/domain/symbols/Student";
+import userEvent from "@testing-library/user-event";
+import { toast } from "@/hooks/use-toast";
+import { useParams } from "react-router";
+import { AbstractFailure } from "@/academic/domain/entities/failure";
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof import("react-router")>("react-router");
+  return {
+    ...actual,
+    useParams: vi.fn(),
+  };
+});
+
+function provideMocks({ get, update }: { get: GetStudentUseCase; update: UpdateStudentUseCase }) {
+  useInjectionMock.mockImplementation((symbol) => {
+    if (symbol === STUDENT_SYMBOLS.GET_USE_CASE) return get;
+    if (symbol === STUDENT_SYMBOLS.UPDATE_USE_CASE) return update;
+    return null;
+  });
+}
+
+describe("StudentEditContainer", () => {
+  const getUseCase = {
+    execute: vi.fn().mockResolvedValue(
+      mockRight({ id: 1, firstName: "Juan", lastName: "Pérez", uuidParallel: "P1" })
+    ),
+  } as unknown as GetStudentUseCase;
+
+  const updateUseCase = {
+    execute: vi.fn().mockResolvedValue(
+      mockRight({ id: 1, firstName: "Juan", lastName: "Pérez", uuidParallel: "P1" })
+    ),
+  } as unknown as UpdateStudentUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provideMocks({ get: getUseCase, update: updateUseCase });
+    (useParams as Mock).mockReturnValue({ id: "1" });
+  });
+
+  it("carga datos del estudiante al montar", async () => {
+    render(
+      <MemoryRouter>
+        <StudentEditContainer />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(getUseCase.execute).toHaveBeenCalled();
+    });
+
+    expect(await screen.findByDisplayValue("Juan")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Pérez")).toBeInTheDocument();
+  });
+
+  it("ejecuta updateUseCase al enviar el formulario", async () => {
+    render(
+      <MemoryRouter>
+        <StudentEditContainer />
+      </MemoryRouter>
+    );
+
+    const firstNameInput = await screen.findByLabelText(/Nombre/i);
+    await userEvent.clear(firstNameInput);
+    await userEvent.type(firstNameInput, "Pedro");
+
+    const lastNameInput = screen.getByLabelText(/Apellido/i);
+    await userEvent.clear(lastNameInput);
+    await userEvent.type(lastNameInput, "Gómez");
+
+    await userEvent.click(screen.getByText("Guardar"));
+
+    await waitFor(() => {
+      expect(updateUseCase.execute).toHaveBeenCalled();
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Estudiante actualizado",
+        })
+      );
+    });
+  });
+
+  it("muestra toast de error si getUseCase falla", async () => {
+    getUseCase.execute = vi.fn().mockResolvedValue(
+      mockLeft([new AbstractFailure("error", "Error al obtener estudiante", "root")])
+    );
+    provideMocks({ get: getUseCase, update: updateUseCase });
+
+    render(
+      <MemoryRouter>
+        <StudentEditContainer />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Error",
+          description: expect.stringContaining("Error al obtener el estudiante"),
+        })
+      );
+    });
+  });
+});
+

--- a/src/academic/presentation/ui/Student/Edit/StudentEditContainer.tsx
+++ b/src/academic/presentation/ui/Student/Edit/StudentEditContainer.tsx
@@ -14,28 +14,36 @@ export const StudentEditContainer = () => {
     const updateUseCase = useInjection<UpdateStudentUseCase>(STUDENT_SYMBOLS.UPDATE_USE_CASE);
     const getUseCase = useInjection<GetStudentUseCase>(STUDENT_SYMBOLS.GET_USE_CASE);
 
-    const { handleSubmit, register, watch, setValue, formState: { errors, isSubmitting } } = useForm<UpdateStudentCommand>();
+    const { handleSubmit, register, watch, setValue, formState: { errors, isSubmitting } } = useForm<UpdateStudentCommand>({
+        defaultValues: {
+            id: 0,
+            firstName: "",
+            lastName: "",
+            uuidParallel: "",
+        },
+    });
 
     const formData = watch();
 
     const fetchStudent = useCallback(async () => {
         if (!id) return;
         const res = await getUseCase.execute(new GetStudentCommand(Number(id)));
-        res.ifRight((student) => {
-            if (!student) return;
-            setValue("id", student.id);
-            setValue("firstName", student.firstName);
-            setValue("lastName", student.lastName);
-            setValue("uuidParallel", student.uuidParallel);
-        });
-        res.ifLeft((failures) => {
-            toast({
-                title: "Error",
-                description: "Error al obtener el estudiante: " + failures.map(f => f.message).join(", "),
-                duration: 5000,
-                variant: "destructive",
+        res
+            .ifRight((student) => {
+                if (!student) return;
+                setValue("id", student.id);
+                setValue("firstName", student.firstName);
+                setValue("lastName", student.lastName);
+                setValue("uuidParallel", student.uuidParallel);
+            })
+            .ifLeft((failures) => {
+                toast({
+                    title: "Error",
+                    description: "Error al obtener el estudiante: " + failures.map(f => f.message).join(", "),
+                    duration: 5000,
+                    variant: "destructive",
+                });
             });
-        });
     }, [getUseCase, id, setValue]);
 
     useEffect(() => {
@@ -44,21 +52,22 @@ export const StudentEditContainer = () => {
 
     const onSubmit = async (data: UpdateStudentCommand) => {
         const res = await updateUseCase.execute(data);
-        res.ifRight((student) => {
-            toast({
-                title: "Estudiante actualizado",
-                description: `El estudiante ${student?.firstName} ${student?.lastName} ha sido actualizado.`,
-                duration: 5000,
+        res
+            .ifRight((student) => {
+                toast({
+                    title: "Estudiante actualizado",
+                    description: `El estudiante ${student?.firstName} ${student?.lastName} ha sido actualizado.`,
+                    duration: 5000,
+                });
+            })
+            .ifLeft((failures) => {
+                toast({
+                    title: "Error",
+                    description: "Error al actualizar el estudiante: " + failures.map(f => f.message).join(", "),
+                    duration: 5000,
+                    variant: "destructive",
+                });
             });
-        });
-        res.ifLeft((failures) => {
-            toast({
-                title: "Error",
-                description: "Error al actualizar el estudiante: " + failures.map(f => f.message).join(", "),
-                duration: 5000,
-                variant: "destructive",
-            });
-        });
     };
 
     return (

--- a/src/academic/presentation/ui/Student/Edit/StudentEditPresenter.test.tsx
+++ b/src/academic/presentation/ui/Student/Edit/StudentEditPresenter.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import { useForm } from "react-hook-form";
+import { UpdateStudentCommand } from "@/academic/application/usecases/student/UpdateStudentUseCase";
+import { StudentEditPresenter } from "./StudentEditPresenter";
+
+function Wrapper({
+  formData,
+  onCancel,
+  loading,
+  _handleSubmit,
+}: Readonly<{
+  formData: UpdateStudentCommand;
+  onCancel: () => void;
+  loading?: boolean;
+  _handleSubmit: (data: UpdateStudentCommand) => void;
+}>) {
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<UpdateStudentCommand>({
+    defaultValues: { ...formData },
+  });
+
+  return (
+    <MemoryRouter>
+      <StudentEditPresenter
+        onCancel={onCancel}
+        loading={loading}
+        handleSubmit={handleSubmit(_handleSubmit)}
+        register={register}
+        errors={errors}
+        formData={formData}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe("StudentEditPresenter", () => {
+  it("renderiza el título y botones", async () => {
+    render(
+      <Wrapper
+        formData={new UpdateStudentCommand(1, "", "", "")}
+        onCancel={vi.fn()}
+        _handleSubmit={vi.fn()}
+        loading={false}
+      />
+    );
+    const titles = await screen.findAllByText(/Editar Estudiante/i);
+    expect(titles.length).toBeGreaterThan(0);
+    expect(screen.getByText("Guardar")).toBeInTheDocument();
+    expect(screen.getByText("Cancelar")).toBeInTheDocument();
+  });
+
+  it("muestra errores de validación", async () => {
+    render(
+      <Wrapper
+        formData={new UpdateStudentCommand(1, "", "", "")}
+        onCancel={vi.fn()}
+        _handleSubmit={vi.fn()}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByText("Guardar"));
+    expect(await screen.findByText("El nombre es obligatorio")).toBeInTheDocument();
+    expect(await screen.findByText("El apellido es obligatorio")).toBeInTheDocument();
+  });
+
+  it("llama a onCancel al hacer clic en Cancelar", () => {
+    const onCancel = vi.fn();
+    render(
+      <Wrapper
+        formData={new UpdateStudentCommand(1, "", "", "")}
+        onCancel={onCancel}
+        _handleSubmit={vi.fn()}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByText("Cancelar"));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("deshabilita el botón Guardar cuando loading es true", () => {
+    render(
+      <Wrapper
+        formData={new UpdateStudentCommand(1, "", "", "")}
+        onCancel={vi.fn()}
+        _handleSubmit={vi.fn()}
+        loading={true}
+      />
+    );
+    expect(screen.getByText("Guardando...")).toBeDisabled();
+  });
+});
+

--- a/src/academic/presentation/ui/Student/Edit/StudentEditPresenter.tsx
+++ b/src/academic/presentation/ui/Student/Edit/StudentEditPresenter.tsx
@@ -52,6 +52,9 @@ export const StudentEditPresenter = ({
                                             id="firstName"
                                             {...register("firstName", { required: "El nombre es obligatorio" })}
                                         />
+                                        {errors.firstName && (
+                                            <div className="text-destructive text-sm">{errors.firstName.message}</div>
+                                        )}
                                     </div>
                                     <div className="space-y-2">
                                         <Label htmlFor="lastName">Apellido *</Label>
@@ -59,6 +62,9 @@ export const StudentEditPresenter = ({
                                             id="lastName"
                                             {...register("lastName", { required: "El apellido es obligatorio" })}
                                         />
+                                        {errors.lastName && (
+                                            <div className="text-destructive text-sm">{errors.lastName.message}</div>
+                                        )}
                                     </div>
                                     <div className="space-y-2 md:col-span-2">
                                         <Label htmlFor="uuidParallel">Paralelo *</Label>

--- a/src/academic/presentation/ui/Student/List/StudentListContainer.test.tsx
+++ b/src/academic/presentation/ui/Student/List/StudentListContainer.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router";
+import { useInjectionMock, mockLeft, mockRight } from "@/setupTests";
+import { STUDENT_SYMBOLS } from "@/academic/domain/symbols/Student";
+import { ListStudentsUseCase } from "@/academic/application/usecases/student/ListStudentsUseCase";
+import { StudentListContainer } from "./StudentListContainer";
+import { Page } from "@/lib/utils";
+import { toast } from "@/hooks/use-toast";
+
+
+describe("StudentListContainer", () => {
+  let listUseCase: ListStudentsUseCase = {
+    execute: vi.fn().mockResolvedValue(
+      mockRight({ content: [], page: 1, size: 10, total: 0, totalPage: 0 })
+    ),
+  } as unknown as ListStudentsUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useInjectionMock.mockImplementation((symbol) => {
+      if (symbol === STUDENT_SYMBOLS.LIST_USE_CASE) return listUseCase;
+      return null;
+    });
+  });
+
+  it("muestra mensaje de error si la carga falla", async () => {
+    listUseCase = {
+      execute: vi.fn().mockResolvedValue(
+        mockLeft([{ message: "Error de red", code: "NETWORK", field: "root" }])
+      ),
+    } as unknown as ListStudentsUseCase;
+
+    render(
+      <MemoryRouter>
+        <StudentListContainer />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Error",
+          description: expect.stringContaining("Error de red"),
+        })
+      );
+    });
+  });
+
+  it("muestra lista de estudiantes si la carga es exitosa", async () => {
+    listUseCase = {
+      execute: vi.fn().mockResolvedValue(
+        mockRight({
+          content: [
+            { id: 1, firstName: "Juan", lastName: "Pérez", uuidParallel: "P1" },
+          ],
+          page: 1,
+          size: 10,
+          total: 1,
+          totalPage: 1,
+        } as Page<any>)
+      ),
+    } as unknown as ListStudentsUseCase;
+
+    render(
+      <MemoryRouter>
+        <StudentListContainer />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Juan Pérez")).toBeInTheDocument();
+    });
+  });
+
+  it("muestra skeleton mientras carga", async () => {
+    listUseCase = {
+      execute: vi.fn(() => new Promise(() => {})),
+    } as unknown as ListStudentsUseCase;
+
+    render(
+      <MemoryRouter>
+        <StudentListContainer />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("status")).toBeInTheDocument();
+  });
+});
+

--- a/src/academic/presentation/ui/Student/List/StudentListPresenter.test.tsx
+++ b/src/academic/presentation/ui/Student/List/StudentListPresenter.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import { StudentListPresenter } from "./StudentListPresenter";
+import { Student } from "@/academic/domain/entities/Student";
+import { Page } from "@/lib/utils";
+
+const defaultProps = {
+  students: {
+    content: [] as Student[],
+    page: 1,
+    size: 10,
+    total: 0,
+    totalPage: 0,
+  } as Page<Student>,
+  loading: false,
+  error: null as string | null,
+  searchTerm: "",
+  onSearchChange: vi.fn(),
+  onAddStudent: vi.fn(),
+};
+
+const renderPresenter = (
+  props: Partial<React.ComponentProps<typeof StudentListPresenter>> = {}
+) => {
+  return render(
+    <MemoryRouter>
+      <StudentListPresenter {...defaultProps} {...props} />
+    </MemoryRouter>
+  );
+};
+
+describe("StudentListPresenter", () => {
+  it("muestra skeleton mientras carga", async () => {
+    renderPresenter({ loading: true });
+    expect(await screen.findByRole("status")).toBeInTheDocument();
+  });
+
+  it("muestra mensaje de error", () => {
+    const error = "Error de red";
+    renderPresenter({ error });
+    expect(screen.getByText(error)).toBeInTheDocument();
+  });
+
+  it("muestra estudiantes", () => {
+    const students: Page<Student> = {
+      content: [new Student(1, "Juan", "Pérez", "P1")],
+      page: 1,
+      size: 10,
+      total: 1,
+      totalPage: 1,
+    };
+    renderPresenter({ students });
+    expect(screen.getByText("Juan Pérez")).toBeInTheDocument();
+  });
+
+  it("muestra mensaje cuando no hay estudiantes", () => {
+    renderPresenter({ students: { ...defaultProps.students, content: [] } });
+    expect(screen.getByText("No hay estudiantes registrados aún.")).toBeInTheDocument();
+  });
+
+  it("muestra controles de paginación", () => {
+    const students: Page<Student> = {
+      content: [],
+      page: 1,
+      size: 10,
+      total: 20,
+      totalPage: 2,
+    };
+    renderPresenter({ students });
+    expect(
+      screen.getByText("Página 1 de 2 - Total de estudiantes: 20")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Página anterior")).toBeInTheDocument();
+    expect(screen.getByText("Página siguiente")).toBeInTheDocument();
+  });
+});
+

--- a/src/academic/presentation/ui/Student/List/StudentListPresenter.tsx
+++ b/src/academic/presentation/ui/Student/List/StudentListPresenter.tsx
@@ -4,12 +4,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Search, Plus } from "lucide-react";
+import { Search, Plus, UserX } from "lucide-react";
 import { Student } from "@/academic/domain/entities/Student";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Pagination, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Page } from "@/lib/utils";
 
 interface StudentListPresenterProps {
-    students: Student[];
+    students: Page<Student>;
     loading: boolean;
     error: string | null;
     searchTerm: string;
@@ -49,11 +51,11 @@ export function StudentListPresenter({
                     </div>
 
                     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                        {loading && <Skeleton className="h-24 w-full col-span-full" />}
+                        {loading && <Skeleton role="status" className="h-24 w-full col-span-full" />}
                         {error && (
                             <div className="text-destructive text-center col-span-full">{error}</div>
                         )}
-                        {students.map((student) => (
+                        {students.content.map((student) => (
                             <Card key={student.id} className="hover:shadow-md transition-shadow">
                                 <CardContent className="p-4">
                                     <div className="flex items-start gap-3">
@@ -81,11 +83,39 @@ export function StudentListPresenter({
                         ))}
                     </div>
 
-                    {students.length === 0 && !loading && !error && (
-                        <div className="text-center py-8 text-muted-foreground">
-                            No se encontraron estudiantes
+                    {students.content.length === 0 && !loading && !error && (
+                        <div className="col-span-3 text-center py-8 text-muted-foreground w-full flex flex-col items-center space-y-4">
+                            <UserX className="h-12 w-12 text-muted-foreground" />
+                            <p className="text-lg font-medium">
+                                {searchTerm
+                                    ? `No encontramos resultados para "${searchTerm}".`
+                                    : "No hay estudiantes registrados aún."}
+                            </p>
+                            {!searchTerm && (
+                                <Button onClick={onAddStudent}>
+                                    Registrar estudiante
+                                </Button>
+                            )}
                         </div>
                     )}
+
+                    <Pagination className="col-span-full justify-center">
+                        <PaginationPrevious className="bg-background" />
+                        {students.total > 1 && Array.from({ length: students.totalPage }).map((_, index) => (
+                            <PaginationLink
+                                key={`page-${index + 1}`}
+                                href={`/estudiantes?page=${index + 1}`}
+                                isActive={index === students.page}
+                                className="bg-background"
+                            >
+                                {index + 1}
+                            </PaginationLink>
+                        ))}
+                        <PaginationNext className="bg-background" />
+                    </Pagination>
+                    <div className="col-span-full text-center text-sm text-muted-foreground">
+                        Página {students.page} de {students.totalPage} - Total de estudiantes: {students.total}
+                    </div>
                 </CardContent>
             </Card>
         </div>

--- a/src/academic/presentation/ui/Teacher/Create/TeacherCreatePresenter.tsx
+++ b/src/academic/presentation/ui/Teacher/Create/TeacherCreatePresenter.tsx
@@ -108,7 +108,7 @@ export const TeacherCreatePresenter = ({
                                                 <Select
                                                     name={field.name}
                                                     onValueChange={field.onChange}
-                                                    value={field.value}
+                                                    value={field.value ?? ""}
                                                 >
                                                     <SelectTrigger>
                                                         <SelectValue placeholder="Seleccionar género" />

--- a/src/academic/presentation/ui/Teacher/Edit/TeacherEditPresenter.tsx
+++ b/src/academic/presentation/ui/Teacher/Edit/TeacherEditPresenter.tsx
@@ -107,7 +107,7 @@ export const TeacherEditPresenter = ({
                                                 <Select
                                                     name={field.name}
                                                     onValueChange={field.onChange}
-                                                    value={field.value}
+                                                    value={field.value ?? ""}
                                                 >
                                                     <SelectTrigger>
                                                         <SelectValue placeholder="Seleccionar género" />

--- a/src/academic/presentation/ui/Teacher/List/TeacherListContainer.test.tsx
+++ b/src/academic/presentation/ui/Teacher/List/TeacherListContainer.test.tsx
@@ -124,15 +124,19 @@ describe("TeacherListContainer", () => {
         });
 
     });
-    it("muestra skeleton mientras carga", () => {
-        const { getByRole } = render(
+    it("muestra skeleton mientras carga", async () => {
+        listUseCase = {
+            execute: vi.fn(() => new Promise(() => {})),
+        } as unknown as ListTeachersUseCase;
+
+        const { findByRole } = render(
             <MemoryRouter>
                 <TeacherListContainer />
             </MemoryRouter>
         );
-        expect(getByRole("status")).toBeInTheDocument(); // Skeleton tiene role="status"
-    }
-    );
+
+        expect(await findByRole("status")).toBeInTheDocument(); // Skeleton tiene role="status"
+    });
 
     it("llama a la función de búsqueda al cambiar el término de búsqueda", async () => {
         

--- a/src/academic/presentation/ui/TeacherAssignment/Create/TeacherAssignmentCreateContainer.test.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/Create/TeacherAssignmentCreateContainer.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import { TeacherAssignmentCreateContainer } from "./TeacherAssignmentCreateContainer";
+import { useInjectionMock, mockLeft } from "@/setupTests";
+import { TEACHER_ASSIGNMENT_SYMBOLS } from "@/academic/domain/symbols/TeacherAssignment";
+import { CreateTeacherAssignmentUseCase } from "@/academic/application/usecases/teacher-assignment/CreateTeacherAssignmentUseCase";
+import { toast } from "@/hooks/use-toast";
+
+describe("TeacherAssignmentCreateContainer", () => {
+  let executeMock: CreateTeacherAssignmentUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executeMock = { execute: vi.fn() } as unknown as CreateTeacherAssignmentUseCase;
+    useInjectionMock.mockImplementation((symbol) => {
+      if (symbol === TEACHER_ASSIGNMENT_SYMBOLS.CREATE_USE_CASE) return executeMock;
+      return null;
+    });
+  });
+
+  it("crea asignación y muestra toast de éxito", async () => {
+    executeMock = {
+      execute: vi.fn().mockResolvedValue({
+        ifRight: (fn: () => void) => {
+          fn();
+          return { ifLeft: () => {} };
+        },
+      }),
+    } as unknown as CreateTeacherAssignmentUseCase;
+
+    render(
+      <MemoryRouter>
+        <TeacherAssignmentCreateContainer />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText(/ID Docente/i), { target: { value: "1" } });
+    fireEvent.change(screen.getByLabelText(/ID Curso/i), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText(/ID Asignatura/i), { target: { value: "3" } });
+    fireEvent.change(screen.getByLabelText(/Año Lectivo/i), { target: { value: "2023" } });
+
+    fireEvent.click(screen.getByText("Guardar"));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Asignación creada",
+          description: expect.stringContaining("La asignación docente ha sido creada"),
+        })
+      );
+    });
+  });
+
+  it("muestra error si falla la creación", async () => {
+    executeMock = {
+      execute: vi.fn().mockResolvedValue(
+        mockLeft([{ message: "Error al crear", code: "E", field: "root" }])
+      ),
+    } as unknown as CreateTeacherAssignmentUseCase;
+
+    render(
+      <MemoryRouter>
+        <TeacherAssignmentCreateContainer />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText(/ID Docente/i), { target: { value: "1" } });
+    fireEvent.change(screen.getByLabelText(/ID Curso/i), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText(/ID Asignatura/i), { target: { value: "3" } });
+    fireEvent.change(screen.getByLabelText(/Año Lectivo/i), { target: { value: "2023" } });
+
+    fireEvent.click(screen.getByText("Guardar"));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Error",
+          description: expect.stringContaining("Error al crear"),
+          variant: "destructive",
+        })
+      );
+    });
+  });
+});

--- a/src/academic/presentation/ui/TeacherAssignment/Create/TeacherAssignmentCreatePresenter.test.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/Create/TeacherAssignmentCreatePresenter.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import { useForm } from "react-hook-form";
+import { CreateTeacherAssignmentCommand } from "@/academic/application/usecases/teacher-assignment/CreateTeacherAssignmentUseCase";
+import { TeacherAssignmentCreatePresenter } from "./TeacherAssignmentCreatePresenter";
+
+function Wrapper({ onCancel, loading, _handleSubmit }: { onCancel: () => void; loading?: boolean; _handleSubmit: (data: CreateTeacherAssignmentCommand) => void; }) {
+  const { register, formState: { errors }, handleSubmit } = useForm<CreateTeacherAssignmentCommand>({ defaultValues: { teacherId: undefined, courseId: undefined, subjectId: undefined, schoolYearId: "" } });
+  return (
+    <MemoryRouter>
+      <TeacherAssignmentCreatePresenter
+        onCancel={onCancel}
+        loading={loading}
+        handleSubmit={handleSubmit(_handleSubmit)}
+        register={register}
+        errors={errors}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe("TeacherAssignmentCreatePresenter", () => {
+  it("renderiza el título y botones", () => {
+    render(<Wrapper onCancel={vi.fn()} loading={false} _handleSubmit={vi.fn()} />);
+    expect(screen.getByText("Registrar Asignación")).toBeInTheDocument();
+    expect(screen.getByText("Guardar")).toBeInTheDocument();
+    expect(screen.getByText("Cancelar")).toBeInTheDocument();
+  });
+
+  it("muestra errores de validación", async () => {
+    render(<Wrapper onCancel={vi.fn()} loading={false} _handleSubmit={vi.fn()} />);
+    fireEvent.click(screen.getByText("Guardar"));
+    expect(await screen.findAllByText("Obligatorio")).toHaveLength(4);
+  });
+
+  it("llama a onCancel al hacer clic en Cancelar", () => {
+    const onCancel = vi.fn();
+    render(<Wrapper onCancel={onCancel} loading={false} _handleSubmit={vi.fn()} />);
+    fireEvent.click(screen.getByText("Cancelar"));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("deshabilita el botón Guardar cuando loading es true", () => {
+    render(<Wrapper onCancel={vi.fn()} loading={true} _handleSubmit={vi.fn()} />);
+    expect(screen.getByText("Guardando...")).toBeDisabled();
+  });
+});

--- a/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListContainer.test.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListContainer.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router";
+import { useInjectionMock, mockLeft, mockRight } from "@/setupTests";
+import { TEACHER_ASSIGNMENT_SYMBOLS } from "@/academic/domain/symbols/TeacherAssignment";
+import { ListTeacherAssignmentsUseCase } from "@/academic/application/usecases/teacher-assignment/ListTeacherAssignmentsUseCase";
+import { TeacherAssignmentListContainer } from "./TeacherAssignmentListContainer";
+import { TeacherAssignment } from "@/academic/domain/entities/TeacherAssignment";
+import { toast } from "@/hooks/use-toast";
+
+describe("TeacherAssignmentListContainer", () => {
+  let listUseCase: ListTeacherAssignmentsUseCase = {
+    execute: vi.fn().mockResolvedValue(mockRight<TeacherAssignment[]>([])),
+  } as unknown as ListTeacherAssignmentsUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useInjectionMock.mockImplementation((symbol) => {
+      if (symbol === TEACHER_ASSIGNMENT_SYMBOLS.LIST_USE_CASE) return listUseCase;
+      return null;
+    });
+  });
+
+  it("muestra mensaje de error si la carga falla", async () => {
+    listUseCase = {
+      execute: vi.fn().mockResolvedValue(
+        mockLeft([{ message: "Error de red", code: "NETWORK", field: "root" }])
+      ),
+    } as unknown as ListTeacherAssignmentsUseCase;
+
+    render(
+      <MemoryRouter>
+        <TeacherAssignmentListContainer />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Error",
+          description: expect.stringContaining("Error de red"),
+        })
+      );
+    });
+  });
+
+  it("muestra lista de asignaciones si la carga es exitosa", async () => {
+    listUseCase = {
+      execute: vi.fn().mockResolvedValue(
+        mockRight([
+          { id: 1, teacherId: 1, courseId: 2, subjectId: 3, schoolYearId: "2023" } as TeacherAssignment,
+        ])
+      ),
+    } as unknown as ListTeacherAssignmentsUseCase;
+
+    render(
+      <MemoryRouter>
+        <TeacherAssignmentListContainer />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Docente: 1/)).toBeInTheDocument();
+    });
+  });
+
+  it("muestra skeleton mientras carga", async () => {
+    listUseCase = {
+      execute: vi.fn(() => new Promise(() => {})),
+    } as unknown as ListTeacherAssignmentsUseCase;
+
+    render(
+      <MemoryRouter>
+        <TeacherAssignmentListContainer />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("status")).toBeInTheDocument();
+  });
+});

--- a/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListContainer.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListContainer.tsx
@@ -4,19 +4,28 @@ import { TEACHER_ASSIGNMENT_SYMBOLS } from "@/academic/domain/symbols/TeacherAss
 import { useInjection } from "inversify-react";
 import { useCallback, useEffect, useState } from "react";
 import { TeacherAssignment } from "@/academic/domain/entities/TeacherAssignment";
+import { toast } from "@/hooks/use-toast";
+import { useNavigate } from "react-router";
 
 export const TeacherAssignmentListContainer = () => {
   const listUseCase = useInjection<ListTeacherAssignmentsUseCase>(TEACHER_ASSIGNMENT_SYMBOLS.LIST_USE_CASE);
+  const navigate = useNavigate();
   const [assignments, setAssignments] = useState<TeacherAssignment[]>([]);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
 
   const fetchData = useCallback(async () => {
     setLoading(true);
-    setError(null);
     const res = await listUseCase.execute(new ListTeacherAssignmentsCommand());
-    res.ifRight(data => setAssignments(data ?? [])).ifLeft(f => setError(f.map(x => x.message).join(", ")));
+    res
+      .ifRight(data => setAssignments(data ?? []))
+      .ifLeft(f =>
+        toast({
+          title: "Error",
+          description: f.map(x => x.message).join(", "),
+          variant: "destructive",
+        })
+      );
     setLoading(false);
   }, [listUseCase]);
 
@@ -28,10 +37,10 @@ export const TeacherAssignmentListContainer = () => {
     <TeacherAssignmentListPresenter
       assignments={filtered}
       loading={loading}
-      error={error}
+      error={null}
       searchTerm={searchTerm}
       onSearchChange={setSearchTerm}
-      onAddAssignment={() => {}}
+      onAddAssignment={() => navigate("/asignaciones-docentes/nuevo")}
     />
   );
 };

--- a/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListPresenter.test.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListPresenter.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import { TeacherAssignmentListPresenter } from "./TeacherAssignmentListPresenter";
+import { TeacherAssignment } from "@/academic/domain/entities/TeacherAssignment";
+
+const defaultProps = {
+  assignments: [] as TeacherAssignment[],
+  loading: false,
+  error: null as string | null,
+  searchTerm: "",
+  onSearchChange: vi.fn(),
+  onAddAssignment: vi.fn(),
+};
+
+const renderPresenter = (props: Partial<React.ComponentProps<typeof TeacherAssignmentListPresenter>> = {}) => {
+  return render(
+    <MemoryRouter>
+      <TeacherAssignmentListPresenter {...defaultProps} {...props} />
+    </MemoryRouter>
+  );
+};
+
+describe("TeacherAssignmentListPresenter", () => {
+  it("muestra skeleton mientras carga", async () => {
+    renderPresenter({ loading: true });
+    expect(await screen.findByRole("status")).toBeInTheDocument();
+  });
+
+  it("muestra mensaje de error", () => {
+    const error = "Error de red";
+    renderPresenter({ error });
+    expect(screen.getByText(error)).toBeInTheDocument();
+  });
+
+  it("muestra asignaciones", () => {
+    const assignments: TeacherAssignment[] = [
+      { id: 1, teacherId: 1, courseId: 2, subjectId: 3, schoolYearId: "2023" },
+    ];
+    renderPresenter({ assignments });
+    expect(screen.getByText(/Docente: 1/)).toBeInTheDocument();
+  });
+
+  it("muestra mensaje cuando no hay asignaciones", () => {
+    renderPresenter({ assignments: [] });
+    expect(screen.getByText("No hay asignaciones registradas aún.")).toBeInTheDocument();
+  });
+});

--- a/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListPresenter.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListPresenter.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, Plus } from "lucide-react";
+import { Search, Plus, UserX } from "lucide-react";
 import { TeacherAssignment } from "@/academic/domain/entities/TeacherAssignment";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -31,7 +31,7 @@ export const TeacherAssignmentListPresenter = ({ assignments, loading, error, se
           <Input placeholder="Buscar por docente" value={searchTerm} onChange={e => onSearchChange(e.target.value)} className="max-w-sm" />
         </div>
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {loading && <Skeleton role="status" className="h-24 w-full col-span-full" />}
           {error && <div className="text-destructive text-center col-span-full">{error}</div>}
           {assignments.map(a => (
             <Card key={a.id} className="hover:shadow-md transition-shadow">
@@ -43,7 +43,17 @@ export const TeacherAssignmentListPresenter = ({ assignments, loading, error, se
             </Card>
           ))}
         </div>
-        {assignments.length === 0 && !loading && !error && <div className="text-center py-8 text-muted-foreground">No se encontraron asignaciones</div>}
+        {assignments.length === 0 && !loading && !error && (
+          <div className="col-span-3 text-center py-8 text-muted-foreground w-full flex flex-col items-center space-y-4">
+            <UserX className="h-12 w-12 text-muted-foreground" />
+            <p className="text-lg font-medium">
+              {searchTerm
+                ? `No encontramos resultados para "${searchTerm}".`
+                : "No hay asignaciones registradas aún."}
+            </p>
+            {!searchTerm && <Button onClick={onAddAssignment}>Registrar asignación</Button>}
+          </div>
+        )}
       </CardContent>
     </Card>
   </div>


### PR DESCRIPTION
## Summary
- show validation messages in student create and edit forms
- ensure student edit form initializes values and chains result handling
- make student list skeleton accessible and add student screen tests
- paginate student list like teacher view
- surface student list errors via toast and provide a dynamic empty state
- paginate representative list and add matching form validation
- test representative create, edit and list screens
- cover teacher assignment list and create screens with accessible empty state and toast-driven errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c62d7f48f48330b5a01e01a9546485