### PR TITLE
feat: add pagination to teacher assignments and behavior reports

### DIFF
--- a/src/academic/application/usecases/assessment/ListAssessmentsUseCase.ts
+++ b/src/academic/application/usecases/assessment/ListAssessmentsUseCase.ts
@@ -5,19 +5,26 @@ import { AbstractFailure } from "@/academic/domain/entities/failure";
 import { Assessment } from "@/academic/domain/entities/Assessment";
 import { AssessmentService } from "@/academic/domain/services/AssessmentService";
 import { ASSESSMENT_SYMBOLS } from "@/academic/domain/symbols/Assessment";
+import { Page } from "@/lib/utils";
 
-export class ListAssessmentsCommand implements UseCaseCommand { }
+export class ListAssessmentsCommand implements UseCaseCommand {
+    constructor(
+        public readonly page: number,
+        public readonly limit: number,
+        public readonly studentId?: string
+    ) { }
+}
 
 @injectable()
-export class ListAssessmentsUseCase implements UseCase<Assessment[], ListAssessmentsCommand> {
+export class ListAssessmentsUseCase implements UseCase<Page<Assessment>, ListAssessmentsCommand> {
     constructor(
         @inject(ASSESSMENT_SYMBOLS.SERVICE)
         private service: AssessmentService
     ) { }
 
-    async execute(_: ListAssessmentsCommand): Promise<Either<AbstractFailure[], Assessment[] | undefined>> {
+    async execute(command: ListAssessmentsCommand): Promise<Either<AbstractFailure[], Page<Assessment> | undefined>> {
         try {
-            const assessments = await this.service.list();
+            const assessments = await this.service.list(command.page, command.limit, command.studentId);
             return Right(assessments);
         } catch (error) {
             return Left([AbstractFailure.fromError(error)]);

--- a/src/academic/application/usecases/attendance/ListAttendanceUseCase.ts
+++ b/src/academic/application/usecases/attendance/ListAttendanceUseCase.ts
@@ -5,19 +5,26 @@ import { AbstractFailure } from "@/academic/domain/entities/failure";
 import { Attendance } from "@/academic/domain/entities/Attendance";
 import { AttendanceService } from "@/academic/domain/services/AttendanceService";
 import { ATTENDANCE_SYMBOLS } from "@/academic/domain/symbols/Attendance";
+import { Page } from "@/lib/utils";
 
-export class ListAttendanceCommand implements UseCaseCommand { }
+export class ListAttendanceCommand implements UseCaseCommand {
+    constructor(
+        public page: number,
+        public limit: number,
+        public search?: string
+    ) { }
+}
 
 @injectable()
-export class ListAttendanceUseCase implements UseCase<Attendance[], ListAttendanceCommand> {
+export class ListAttendanceUseCase implements UseCase<Page<Attendance>, ListAttendanceCommand> {
     constructor(
         @inject(ATTENDANCE_SYMBOLS.SERVICE)
         private service: AttendanceService
     ) { }
 
-    async execute(_: ListAttendanceCommand): Promise<Either<AbstractFailure[], Attendance[] | undefined>> {
+    async execute(command: ListAttendanceCommand): Promise<Either<AbstractFailure[], Page<Attendance> | undefined>> {
         try {
-            const list = await this.service.list();
+            const list = await this.service.list(command.page, command.limit, command.search);
             return Right(list);
         } catch (error) {
             return Left([AbstractFailure.fromError(error)]);

--- a/src/academic/application/usecases/behavior-report/ListBehaviorReportsUseCase.ts
+++ b/src/academic/application/usecases/behavior-report/ListBehaviorReportsUseCase.ts
@@ -5,19 +5,26 @@ import { AbstractFailure } from "@/academic/domain/entities/failure";
 import { BehaviorReport } from "@/academic/domain/entities/BehaviorReport";
 import { BehaviorReportService } from "@/academic/domain/services/BehaviorReportService";
 import { BEHAVIOR_REPORT_SYMBOLS } from "@/academic/domain/symbols/BehaviorReport";
+import { Page } from "@/lib/utils";
 
-export class ListBehaviorReportsCommand implements UseCaseCommand { }
+export class ListBehaviorReportsCommand implements UseCaseCommand {
+    constructor(
+        public readonly page: number,
+        public readonly limit: number,
+        public readonly search?: string
+    ) { }
+}
 
 @injectable()
-export class ListBehaviorReportsUseCase implements UseCase<BehaviorReport[], ListBehaviorReportsCommand> {
+export class ListBehaviorReportsUseCase implements UseCase<Page<BehaviorReport>, ListBehaviorReportsCommand> {
     constructor(
         @inject(BEHAVIOR_REPORT_SYMBOLS.SERVICE)
         private service: BehaviorReportService
     ) { }
 
-    async execute(_: ListBehaviorReportsCommand): Promise<Either<AbstractFailure[], BehaviorReport[] | undefined>> {
+    async execute(command: ListBehaviorReportsCommand): Promise<Either<AbstractFailure[], Page<BehaviorReport> | undefined>> {
         try {
-            const reports = await this.service.list();
+            const reports = await this.service.list(command.page, command.limit, command.search);
             return Right(reports);
         } catch (error) {
             return Left([AbstractFailure.fromError(error)]);

--- a/src/academic/application/usecases/enrollment/ListEnrollmentsUseCase.ts
+++ b/src/academic/application/usecases/enrollment/ListEnrollmentsUseCase.ts
@@ -5,19 +5,26 @@ import { AbstractFailure } from "@/academic/domain/entities/failure";
 import { Enrollment } from "@/academic/domain/entities/Enrollment";
 import { EnrollmentService } from "@/academic/domain/services/EnrollmentService";
 import { ENROLLMENT_SYMBOLS } from "@/academic/domain/symbols/Enrollment";
+import { Page } from "@/lib/utils";
 
-export class ListEnrollmentsCommand implements UseCaseCommand { }
+export class ListEnrollmentsCommand implements UseCaseCommand {
+    constructor(
+        public page: number,
+        public limit: number,
+        public search?: string
+    ) { }
+}
 
 @injectable()
-export class ListEnrollmentsUseCase implements UseCase<Enrollment[], ListEnrollmentsCommand> {
+export class ListEnrollmentsUseCase implements UseCase<Page<Enrollment>, ListEnrollmentsCommand> {
     constructor(
         @inject(ENROLLMENT_SYMBOLS.SERVICE)
         private service: EnrollmentService
     ) { }
 
-    async execute(_: ListEnrollmentsCommand): Promise<Either<AbstractFailure[], Enrollment[] | undefined>> {
+    async execute(command: ListEnrollmentsCommand): Promise<Either<AbstractFailure[], Page<Enrollment> | undefined>> {
         try {
-            const enrollments = await this.service.list();
+            const enrollments = await this.service.list(command.page, command.limit, command.search);
             return Right(enrollments);
         } catch (error) {
             return Left([AbstractFailure.fromError(error)]);

--- a/src/academic/application/usecases/meeting/ListMeetingsUseCase.ts
+++ b/src/academic/application/usecases/meeting/ListMeetingsUseCase.ts
@@ -5,19 +5,26 @@ import { AbstractFailure } from "@/academic/domain/entities/failure";
 import { Meeting } from "@/academic/domain/entities/Meeting";
 import { MeetingService } from "@/academic/domain/services/MeetingService";
 import { MEETING_SYMBOLS } from "@/academic/domain/symbols/Meeting";
+import { Page } from "@/lib/utils";
 
-export class ListMeetingsCommand implements UseCaseCommand { }
+export class ListMeetingsCommand implements UseCaseCommand {
+    constructor(
+        public readonly page: number,
+        public readonly limit: number,
+        public readonly topic?: string
+    ) { }
+}
 
 @injectable()
-export class ListMeetingsUseCase implements UseCase<Meeting[], ListMeetingsCommand> {
+export class ListMeetingsUseCase implements UseCase<Page<Meeting>, ListMeetingsCommand> {
     constructor(
         @inject(MEETING_SYMBOLS.SERVICE)
         private service: MeetingService
     ) { }
 
-    async execute(_: ListMeetingsCommand): Promise<Either<AbstractFailure[], Meeting[] | undefined>> {
+    async execute(command: ListMeetingsCommand): Promise<Either<AbstractFailure[], Page<Meeting> | undefined>> {
         try {
-            const meetings = await this.service.list();
+            const meetings = await this.service.list(command.page, command.limit, command.topic);
             return Right(meetings);
         } catch (error) {
             return Left([AbstractFailure.fromError(error)]);

--- a/src/academic/application/usecases/promotion-act/ListPromotionActsUseCase.ts
+++ b/src/academic/application/usecases/promotion-act/ListPromotionActsUseCase.ts
@@ -5,24 +5,27 @@ import { PromotionAct } from "@/academic/domain/entities/PromotionAct";
 import { UseCase, UseCaseCommand } from "../UseCase";
 import { Either, Left, Right } from "purify-ts/Either";
 import { AbstractFailure } from "@/academic/domain/entities/failure";
+import { Page } from "@/lib/utils";
 
 export class ListPromotionActsCommand implements UseCaseCommand {
     constructor(
         public readonly courseId: string,
-        public readonly academicYearId: string
+        public readonly academicYearId: string,
+        public readonly page: number,
+        public readonly limit: number
     ) { }
 }
 
 @injectable()
-export class ListPromotionActsUseCase implements UseCase<PromotionAct[], ListPromotionActsCommand> {
+export class ListPromotionActsUseCase implements UseCase<Page<PromotionAct>, ListPromotionActsCommand> {
     constructor(
         @inject(PROMOTION_ACT_SYMBOLS.SERVICE)
         private service: PromotionActService
     ) { }
 
-    async execute(command: ListPromotionActsCommand): Promise<Either<AbstractFailure[], PromotionAct[] | undefined>> {
+    async execute(command: ListPromotionActsCommand): Promise<Either<AbstractFailure[], Page<PromotionAct> | undefined>> {
         try {
-            const acts = await this.service.list(command.courseId, command.academicYearId);
+            const acts = await this.service.list(command.courseId, command.academicYearId, command.page, command.limit);
             return Right(acts);
         } catch (error) {
             return Left([AbstractFailure.fromError(error)]);

--- a/src/academic/application/usecases/representative/ListRepresentativesUseCase.ts
+++ b/src/academic/application/usecases/representative/ListRepresentativesUseCase.ts
@@ -10,7 +10,8 @@ import { REPRESENTATIVE_SYMBOLS } from "@/academic/domain/symbols/Representative
 export class ListRepresentativesCommand implements UseCaseCommand {
     constructor(
         public readonly page: number,
-        public readonly limit: number
+        public readonly limit: number,
+        public readonly search?: string
     ) { }
 }
 
@@ -23,7 +24,7 @@ export class ListRepresentativesUseCase implements UseCase<Page<Representative>,
 
     async execute(command: ListRepresentativesCommand): Promise<Either<AbstractFailure[], Page<Representative> | undefined>> {
         try {
-            const reps = await this.service.list(command.page, command.limit);
+            const reps = await this.service.list(command.page, command.limit, command.search);
             return Right(reps);
         } catch (error) {
             return Left([AbstractFailure.fromError(error)]);

--- a/src/academic/application/usecases/student/ListStudentsUseCase.ts
+++ b/src/academic/application/usecases/student/ListStudentsUseCase.ts
@@ -11,7 +11,8 @@ export class ListStudentsCommand implements UseCaseCommand {
     constructor(
         public readonly page: number,
         public readonly limit: number,
-        public readonly uuidParallel?: string
+        public readonly uuidParallel?: string,
+        public readonly search?: string
     ) { }
 }
 
@@ -24,7 +25,7 @@ export class ListStudentsUseCase implements UseCase<Page<Student>, ListStudentsC
 
     async execute(command: ListStudentsCommand): Promise<Either<AbstractFailure[], Page<Student> | undefined>> {
         try {
-            const students = await this.service.list(command.page, command.limit, command.uuidParallel);
+            const students = await this.service.list(command.page, command.limit, command.uuidParallel, command.search);
             return Right(students);
         } catch (error) {
             return Left([AbstractFailure.fromError(error)]);

--- a/src/academic/application/usecases/teacher-assignment/ListTeacherAssignmentsUseCase.ts
+++ b/src/academic/application/usecases/teacher-assignment/ListTeacherAssignmentsUseCase.ts
@@ -5,24 +5,27 @@ import { AbstractFailure } from "@/academic/domain/entities/failure";
 import { TeacherAssignment } from "@/academic/domain/entities/TeacherAssignment";
 import { TeacherAssignmentService } from "@/academic/domain/services/TeacherAssignmentService";
 import { TEACHER_ASSIGNMENT_SYMBOLS } from "@/academic/domain/symbols/TeacherAssignment";
+import { Page } from "@/lib/utils";
 
 export class ListTeacherAssignmentsCommand implements UseCaseCommand {
     constructor(
+        public readonly page: number,
+        public readonly limit: number,
         public readonly teacherId?: number,
         public readonly courseId?: number
     ) { }
 }
 
 @injectable()
-export class ListTeacherAssignmentsUseCase implements UseCase<TeacherAssignment[], ListTeacherAssignmentsCommand> {
+export class ListTeacherAssignmentsUseCase implements UseCase<Page<TeacherAssignment>, ListTeacherAssignmentsCommand> {
     constructor(
         @inject(TEACHER_ASSIGNMENT_SYMBOLS.SERVICE)
         private service: TeacherAssignmentService
     ) { }
 
-    async execute(command: ListTeacherAssignmentsCommand): Promise<Either<AbstractFailure[], TeacherAssignment[] | undefined>> {
+    async execute(command: ListTeacherAssignmentsCommand): Promise<Either<AbstractFailure[], Page<TeacherAssignment> | undefined>> {
         try {
-            const result = await this.service.list(command.teacherId, command.courseId);
+            const result = await this.service.list(command.page, command.limit, command.teacherId, command.courseId);
             return Right(result);
         } catch (error) {
             return Left([AbstractFailure.fromError(error)]);

--- a/src/academic/application/usecases/teacher-planning/ListTeacherPlanningsUseCase.ts
+++ b/src/academic/application/usecases/teacher-planning/ListTeacherPlanningsUseCase.ts
@@ -5,25 +5,29 @@ import { AbstractFailure } from "@/academic/domain/entities/failure";
 import { TeacherPlanning } from "@/academic/domain/entities/TeacherPlanning";
 import { TeacherPlanningService } from "@/academic/domain/services/TeacherPlanningService";
 import { TEACHER_PLANNING_SYMBOLS } from "@/academic/domain/symbols/TeacherPlanning";
+import { Page } from "@/lib/utils";
 
 export class ListTeacherPlanningsCommand implements UseCaseCommand {
     constructor(
+        public readonly page: number,
+        public readonly limit: number,
         public readonly teacherId?: number,
         public readonly subjectId?: number,
-        public readonly courseId?: number
+        public readonly courseId?: number,
+        public readonly topic?: string
     ) { }
 }
 
 @injectable()
-export class ListTeacherPlanningsUseCase implements UseCase<TeacherPlanning[], ListTeacherPlanningsCommand> {
+export class ListTeacherPlanningsUseCase implements UseCase<Page<TeacherPlanning>, ListTeacherPlanningsCommand> {
     constructor(
         @inject(TEACHER_PLANNING_SYMBOLS.SERVICE)
         private service: TeacherPlanningService
     ) { }
 
-    async execute(command: ListTeacherPlanningsCommand): Promise<Either<AbstractFailure[], TeacherPlanning[] | undefined>> {
+    async execute(command: ListTeacherPlanningsCommand): Promise<Either<AbstractFailure[], Page<TeacherPlanning> | undefined>> {
         try {
-            const result = await this.service.list(command.teacherId, command.subjectId, command.courseId);
+            const result = await this.service.list(command.page, command.limit, command.teacherId, command.subjectId, command.courseId, command.topic);
             return Right(result);
         } catch (error) {
             return Left([AbstractFailure.fromError(error)]);

--- a/src/academic/domain/interfaces/AssessmentRepository.ts
+++ b/src/academic/domain/interfaces/AssessmentRepository.ts
@@ -1,8 +1,9 @@
 import { Assessment } from "../entities/Assessment";
+import { Page } from "@/lib/utils";
 
 export interface AssessmentRepository {
     create(assessment: Assessment): Promise<Assessment>;
-    list(): Promise<Assessment[]>;
+    list(page: number, limit: number, studentId?: string): Promise<Page<Assessment>>;
     update(assessment: Assessment): Promise<Assessment>;
     delete(id: number): Promise<void>;
 }

--- a/src/academic/domain/interfaces/AttendanceRepository.ts
+++ b/src/academic/domain/interfaces/AttendanceRepository.ts
@@ -1,8 +1,9 @@
 import { Attendance } from "../entities/Attendance";
+import { Page } from "@/lib/utils";
 
 export interface AttendanceRepository {
     create(attendance: Attendance): Promise<Attendance>;
-    list(): Promise<Attendance[]>;
+    list(page: number, limit: number, search?: string): Promise<Page<Attendance>>;
     update(attendance: Attendance): Promise<Attendance>;
     delete(id: number): Promise<void>;
 }

--- a/src/academic/domain/interfaces/BehaviorReportRepository.ts
+++ b/src/academic/domain/interfaces/BehaviorReportRepository.ts
@@ -1,8 +1,9 @@
 import { BehaviorReport } from "../entities/BehaviorReport";
+import { Page } from "@/lib/utils";
 
 export interface BehaviorReportRepository {
     create(report: BehaviorReport): Promise<BehaviorReport>;
-    list(): Promise<BehaviorReport[]>;
+    list(page: number, limit: number, search?: string): Promise<Page<BehaviorReport>>;
     update(report: BehaviorReport): Promise<BehaviorReport>;
     delete(id: number): Promise<void>;
 }

--- a/src/academic/domain/interfaces/EnrollmentRepository.ts
+++ b/src/academic/domain/interfaces/EnrollmentRepository.ts
@@ -1,8 +1,9 @@
 import { Enrollment } from "../entities/Enrollment";
+import { Page } from "@/lib/utils";
 
 export interface EnrollmentRepository {
     create(enrollment: Enrollment): Promise<Enrollment>;
-    list(): Promise<Enrollment[]>;
+    list(page: number, limit: number, search?: string): Promise<Page<Enrollment>>;
     update(enrollment: Enrollment): Promise<Enrollment>;
     delete(id: number): Promise<void>;
 }

--- a/src/academic/domain/interfaces/MeetingRepository.ts
+++ b/src/academic/domain/interfaces/MeetingRepository.ts
@@ -1,8 +1,9 @@
 import { Meeting } from "../entities/Meeting";
+import { Page } from "@/lib/utils";
 
 export interface MeetingRepository {
     create(meeting: Meeting): Promise<Meeting>;
-    list(): Promise<Meeting[]>;
+    list(page: number, limit: number, topic?: string): Promise<Page<Meeting>>;
     update(meeting: Meeting): Promise<Meeting>;
     delete(id: number): Promise<void>;
 }

--- a/src/academic/domain/interfaces/PromotionActRepository.ts
+++ b/src/academic/domain/interfaces/PromotionActRepository.ts
@@ -1,8 +1,9 @@
 import { PromotionAct } from "../entities/PromotionAct";
+import { Page } from "@/lib/utils";
 
 export interface PromotionActRepository {
     create(courseId: string, academicYearId: string, generatedBy: number): Promise<PromotionAct>;
     getById(id: number): Promise<PromotionAct>;
-    list(courseId: string, academicYearId: string): Promise<PromotionAct[]>;
+    list(courseId: string, academicYearId: string, page: number, limit: number): Promise<Page<PromotionAct>>;
     delete(id: number): Promise<void>;
 }

--- a/src/academic/domain/interfaces/RepresentativeRepository.ts
+++ b/src/academic/domain/interfaces/RepresentativeRepository.ts
@@ -3,7 +3,7 @@ import { Page } from "@/lib/utils";
 
 export interface RepresentativeRepository {
     create(rep: Representative): Promise<Representative>;
-    list(page: number, limit: number): Promise<Page<Representative>>;
+    list(page: number, limit: number, search?: string): Promise<Page<Representative>>;
     getById(id: number): Promise<Representative | null>;
     update(rep: Representative): Promise<Representative>;
     delete(id: number): Promise<void>;

--- a/src/academic/domain/interfaces/StudentRepository.ts
+++ b/src/academic/domain/interfaces/StudentRepository.ts
@@ -3,7 +3,7 @@ import { Page } from "@/lib/utils";
 
 export interface StudentRepository {
     create(student: Student): Promise<Student>;
-    list(page: number, limit: number, uuidParallel?: string): Promise<Page<Student>>;
+    list(page: number, limit: number, uuidParallel?: string, search?: string): Promise<Page<Student>>;
     getById(id: number): Promise<Student | null>;
     update(student: Student): Promise<Student>;
     delete(id: number): Promise<void>;

--- a/src/academic/domain/interfaces/TeacherAssignmentRepository.ts
+++ b/src/academic/domain/interfaces/TeacherAssignmentRepository.ts
@@ -1,7 +1,8 @@
 import { TeacherAssignment } from "../entities/TeacherAssignment";
+import { Page } from "@/lib/utils";
 
 export interface TeacherAssignmentRepository {
     create(assignment: TeacherAssignment): Promise<TeacherAssignment>;
     getById(id: number): Promise<TeacherAssignment | null>;
-    list(teacherId?: number, courseId?: number): Promise<TeacherAssignment[]>;
+    list(page: number, limit: number, teacherId?: number, courseId?: number): Promise<Page<TeacherAssignment>>;
 }

--- a/src/academic/domain/interfaces/TeacherPlanningRepository.ts
+++ b/src/academic/domain/interfaces/TeacherPlanningRepository.ts
@@ -1,7 +1,8 @@
 import { TeacherPlanning } from "../entities/TeacherPlanning";
+import { Page } from "@/lib/utils";
 
 export interface TeacherPlanningRepository {
     create(planning: TeacherPlanning): Promise<TeacherPlanning>;
     getById(id: number): Promise<TeacherPlanning | null>;
-    list(teacherId?: number, subjectId?: number, courseId?: number): Promise<TeacherPlanning[]>;
+    list(page: number, limit: number, teacherId?: number, subjectId?: number, courseId?: number, topic?: string): Promise<Page<TeacherPlanning>>;
 }

--- a/src/academic/domain/services/AssessmentService.ts
+++ b/src/academic/domain/services/AssessmentService.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from "inversify";
 import { Assessment } from "../entities/Assessment";
 import { AssessmentRepository } from "../interfaces/AssessmentRepository";
 import { ASSESSMENT_SYMBOLS } from "../symbols/Assessment";
+import { Page } from "@/lib/utils";
 
 @injectable()
 export class AssessmentService {
@@ -14,8 +15,8 @@ export class AssessmentService {
         return this.repository.create(assessment);
     }
 
-    list(): Promise<Assessment[]> {
-        return this.repository.list();
+    list(page: number, limit: number, studentId?: string): Promise<Page<Assessment>> {
+        return this.repository.list(page, limit, studentId);
     }
 
     update(assessment: Assessment): Promise<Assessment> {

--- a/src/academic/domain/services/AttendanceService.ts
+++ b/src/academic/domain/services/AttendanceService.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from "inversify";
 import { Attendance } from "../entities/Attendance";
 import { AttendanceRepository } from "../interfaces/AttendanceRepository";
 import { ATTENDANCE_SYMBOLS } from "../symbols/Attendance";
+import { Page } from "@/lib/utils";
 
 @injectable()
 export class AttendanceService {
@@ -14,8 +15,8 @@ export class AttendanceService {
         return this.repository.create(attendance);
     }
 
-    list(): Promise<Attendance[]> {
-        return this.repository.list();
+    list(page: number, limit: number, search?: string): Promise<Page<Attendance>> {
+        return this.repository.list(page, limit, search);
     }
 
     update(attendance: Attendance): Promise<Attendance> {

--- a/src/academic/domain/services/BehaviorReportService.ts
+++ b/src/academic/domain/services/BehaviorReportService.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from "inversify";
 import { BehaviorReport } from "../entities/BehaviorReport";
 import { BehaviorReportRepository } from "../interfaces/BehaviorReportRepository";
 import { BEHAVIOR_REPORT_SYMBOLS } from "../symbols/BehaviorReport";
+import { Page } from "@/lib/utils";
 
 @injectable()
 export class BehaviorReportService {
@@ -14,8 +15,8 @@ export class BehaviorReportService {
         return this.repository.create(report);
     }
 
-    list(): Promise<BehaviorReport[]> {
-        return this.repository.list();
+    list(page: number, limit: number, search?: string): Promise<Page<BehaviorReport>> {
+        return this.repository.list(page, limit, search);
     }
 
     update(report: BehaviorReport): Promise<BehaviorReport> {

--- a/src/academic/domain/services/EnrollmentService.ts
+++ b/src/academic/domain/services/EnrollmentService.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from "inversify";
 import { Enrollment } from "../entities/Enrollment";
 import { EnrollmentRepository } from "../interfaces/EnrollmentRepository";
 import { ENROLLMENT_SYMBOLS } from "../symbols/Enrollment";
+import { Page } from "@/lib/utils";
 
 @injectable()
 export class EnrollmentService {
@@ -14,8 +15,8 @@ export class EnrollmentService {
         return this.repository.create(enrollment);
     }
 
-    list(): Promise<Enrollment[]> {
-        return this.repository.list();
+    list(page: number, limit: number, search?: string): Promise<Page<Enrollment>> {
+        return this.repository.list(page, limit, search);
     }
 
     update(enrollment: Enrollment): Promise<Enrollment> {

--- a/src/academic/domain/services/MeetingService.ts
+++ b/src/academic/domain/services/MeetingService.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from "inversify";
 import { Meeting } from "../entities/Meeting";
 import { MeetingRepository } from "../interfaces/MeetingRepository";
 import { MEETING_SYMBOLS } from "../symbols/Meeting";
+import { Page } from "@/lib/utils";
 
 @injectable()
 export class MeetingService {
@@ -14,8 +15,8 @@ export class MeetingService {
         return this.repository.create(meeting);
     }
 
-    list(): Promise<Meeting[]> {
-        return this.repository.list();
+    list(page: number, limit: number, topic?: string): Promise<Page<Meeting>> {
+        return this.repository.list(page, limit, topic);
     }
 
     update(meeting: Meeting): Promise<Meeting> {

--- a/src/academic/domain/services/PromotionActService.ts
+++ b/src/academic/domain/services/PromotionActService.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from "inversify";
 import { PROMOTION_ACT_SYMBOLS } from "../symbols/PromotionAct";
 import { PromotionActRepository } from "../interfaces/PromotionActRepository";
 import { PromotionAct } from "../entities/PromotionAct";
+import { Page } from "@/lib/utils";
 
 @injectable()
 export class PromotionActService {
@@ -18,8 +19,8 @@ export class PromotionActService {
         return this.repository.getById(id);
     }
 
-    list(courseId: string, academicYearId: string): Promise<PromotionAct[]> {
-        return this.repository.list(courseId, academicYearId);
+    list(courseId: string, academicYearId: string, page: number, limit: number): Promise<Page<PromotionAct>> {
+        return this.repository.list(courseId, academicYearId, page, limit);
     }
 
     delete(id: number): Promise<void> {

--- a/src/academic/domain/services/RepresentativeService.ts
+++ b/src/academic/domain/services/RepresentativeService.ts
@@ -15,8 +15,8 @@ export class RepresentativeService {
         return this.repository.create(rep);
     }
 
-    async list(page: number, limit: number): Promise<Page<Representative>> {
-        return this.repository.list(page, limit);
+    async list(page: number, limit: number, search?: string): Promise<Page<Representative>> {
+        return this.repository.list(page, limit, search);
     }
 
     async getById(id: number): Promise<Representative | null> {

--- a/src/academic/domain/services/StudentService.ts
+++ b/src/academic/domain/services/StudentService.ts
@@ -15,8 +15,8 @@ export class StudentService {
         return this.repository.create(student);
     }
 
-    async list(page: number, limit: number, uuidParallel?: string): Promise<Page<Student>> {
-        return this.repository.list(page, limit, uuidParallel);
+    async list(page: number, limit: number, uuidParallel?: string, search?: string): Promise<Page<Student>> {
+        return this.repository.list(page, limit, uuidParallel, search);
     }
 
     async getById(id: number): Promise<Student | null> {

--- a/src/academic/domain/services/TeacherAssignmentService.ts
+++ b/src/academic/domain/services/TeacherAssignmentService.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from "inversify";
 import { TeacherAssignmentRepository } from "../interfaces/TeacherAssignmentRepository";
 import { TEACHER_ASSIGNMENT_SYMBOLS } from "../symbols/TeacherAssignment";
 import { TeacherAssignment } from "../entities/TeacherAssignment";
+import { Page } from "@/lib/utils";
 
 @injectable()
 export class TeacherAssignmentService {
@@ -18,7 +19,7 @@ export class TeacherAssignmentService {
         return this.repository.getById(id);
     }
 
-    async list(teacherId?: number, courseId?: number): Promise<TeacherAssignment[]> {
-        return this.repository.list(teacherId, courseId);
+    async list(page: number, limit: number, teacherId?: number, courseId?: number): Promise<Page<TeacherAssignment>> {
+        return this.repository.list(page, limit, teacherId, courseId);
     }
 }

--- a/src/academic/domain/services/TeacherPlanningService.ts
+++ b/src/academic/domain/services/TeacherPlanningService.ts
@@ -2,6 +2,7 @@ import { inject, injectable } from "inversify";
 import { TeacherPlanningRepository } from "../interfaces/TeacherPlanningRepository";
 import { TEACHER_PLANNING_SYMBOLS } from "../symbols/TeacherPlanning";
 import { TeacherPlanning } from "../entities/TeacherPlanning";
+import { Page } from "@/lib/utils";
 
 @injectable()
 export class TeacherPlanningService {
@@ -18,7 +19,7 @@ export class TeacherPlanningService {
         return this.repository.getById(id);
     }
 
-    async list(teacherId?: number, subjectId?: number, courseId?: number): Promise<TeacherPlanning[]> {
-        return this.repository.list(teacherId, subjectId, courseId);
+    async list(page: number, limit: number, teacherId?: number, subjectId?: number, courseId?: number, topic?: string): Promise<Page<TeacherPlanning>> {
+        return this.repository.list(page, limit, teacherId, subjectId, courseId, topic);
     }
 }

--- a/src/academic/infrastructure/api/AssessmentRepositoryImpl.ts
+++ b/src/academic/infrastructure/api/AssessmentRepositoryImpl.ts
@@ -3,6 +3,7 @@ import { Assessment } from "@/academic/domain/entities/Assessment";
 import { ApiInstance } from "./Api";
 import { AssessmentOutputDto } from "./dto/AssessmentDto";
 import { AssessmentMapper } from "./mappers/AssessmentMapper";
+import { Page } from "@/lib/utils";
 
 export class AssessmentRepositoryImpl implements AssessmentRepository {
     async create(assessment: Assessment): Promise<Assessment> {
@@ -13,9 +14,19 @@ export class AssessmentRepositoryImpl implements AssessmentRepository {
         return AssessmentMapper.toDomain(res.data);
     }
 
-    async list(): Promise<Assessment[]> {
-        const res = await ApiInstance.get<AssessmentOutputDto[]>('/assessments');
-        return res.data.map(AssessmentMapper.toDomain);
+    async list(page: number, limit: number, studentId?: string): Promise<Page<Assessment>> {
+        const params = new URLSearchParams();
+        params.append('page', page.toString());
+        params.append('limit', limit.toString());
+        if (studentId) params.append('studentId', studentId);
+        const res = await ApiInstance.get<Page<AssessmentOutputDto>>(
+            '/assessments',
+            { params }
+        );
+        return {
+            ...res.data,
+            content: res.data.content.map(AssessmentMapper.toDomain)
+        };
     }
 
     async update(assessment: Assessment): Promise<Assessment> {

--- a/src/academic/infrastructure/api/AttendanceRepositoryImpl.ts
+++ b/src/academic/infrastructure/api/AttendanceRepositoryImpl.ts
@@ -3,6 +3,7 @@ import { Attendance } from "@/academic/domain/entities/Attendance";
 import { ApiInstance } from "./Api";
 import { AttendanceOutputDto } from "./dto/AttendanceDto";
 import { AttendanceMapper } from "./mappers/AttendanceMapper";
+import { Page } from "@/lib/utils";
 
 export class AttendanceRepositoryImpl implements AttendanceRepository {
     async create(attendance: Attendance): Promise<Attendance> {
@@ -13,9 +14,16 @@ export class AttendanceRepositoryImpl implements AttendanceRepository {
         return AttendanceMapper.toDomain(res.data);
     }
 
-    async list(): Promise<Attendance[]> {
-        const res = await ApiInstance.get<AttendanceOutputDto[]>('/attendance');
-        return res.data.map(AttendanceMapper.toDomain);
+    async list(page: number, limit: number, search?: string): Promise<Page<Attendance>> {
+        const params = new URLSearchParams();
+        params.append('page', page.toString());
+        params.append('limit', limit.toString());
+        if (search) params.append('search', search);
+        const res = await ApiInstance.get<Page<AttendanceOutputDto>>('/attendance', { params });
+        return {
+            ...res.data,
+            content: res.data.content.map(AttendanceMapper.toDomain)
+        };
     }
 
     async update(attendance: Attendance): Promise<Attendance> {

--- a/src/academic/infrastructure/api/BehaviorReportRepositoryImpl.ts
+++ b/src/academic/infrastructure/api/BehaviorReportRepositoryImpl.ts
@@ -3,6 +3,7 @@ import { BehaviorReport } from "@/academic/domain/entities/BehaviorReport";
 import { ApiInstance } from "./Api";
 import { BehaviorReportOutputDto } from "./dto/BehaviorReportDto";
 import { BehaviorReportMapper } from "./mappers/BehaviorReportMapper";
+import { Page } from "@/lib/utils";
 
 export class BehaviorReportRepositoryImpl implements BehaviorReportRepository {
     async create(report: BehaviorReport): Promise<BehaviorReport> {
@@ -13,9 +14,16 @@ export class BehaviorReportRepositoryImpl implements BehaviorReportRepository {
         return BehaviorReportMapper.toDomain(res.data);
     }
 
-    async list(): Promise<BehaviorReport[]> {
-        const res = await ApiInstance.get<BehaviorReportOutputDto[]>('/behavior-reports');
-        return res.data.map(BehaviorReportMapper.toDomain);
+    async list(page: number, limit: number, search?: string): Promise<Page<BehaviorReport>> {
+        const params = new URLSearchParams();
+        params.append('page', page.toString());
+        params.append('limit', limit.toString());
+        if (search) params.append('search', search);
+        const res = await ApiInstance.get<Page<BehaviorReportOutputDto>>('/behavior-reports', { params });
+        return {
+            ...res.data,
+            content: res.data.content.map(BehaviorReportMapper.toDomain)
+        };
     }
 
     async update(report: BehaviorReport): Promise<BehaviorReport> {

--- a/src/academic/infrastructure/api/EnrollmentRepositoryImpl.ts
+++ b/src/academic/infrastructure/api/EnrollmentRepositoryImpl.ts
@@ -3,6 +3,7 @@ import { Enrollment } from "@/academic/domain/entities/Enrollment";
 import { ApiInstance } from "./Api";
 import { EnrollmentOutputDto } from "./dto/EnrollmentDto";
 import { EnrollmentMapper } from "./mappers/EnrollmentMapper";
+import { Page } from "@/lib/utils";
 
 export class EnrollmentRepositoryImpl implements EnrollmentRepository {
     async create(enrollment: Enrollment): Promise<Enrollment> {
@@ -13,9 +14,16 @@ export class EnrollmentRepositoryImpl implements EnrollmentRepository {
         return EnrollmentMapper.toDomain(res.data);
     }
 
-    async list(): Promise<Enrollment[]> {
-        const res = await ApiInstance.get<EnrollmentOutputDto[]>('/enrollments');
-        return res.data.map(EnrollmentMapper.toDomain);
+    async list(page: number, limit: number, search?: string): Promise<Page<Enrollment>> {
+        const params = new URLSearchParams();
+        params.append('page', page.toString());
+        params.append('limit', limit.toString());
+        if (search) params.append('search', search);
+        const res = await ApiInstance.get<Page<EnrollmentOutputDto>>('/enrollments', { params });
+        return {
+            ...res.data,
+            content: res.data.content.map(EnrollmentMapper.toDomain)
+        };
     }
 
     async update(enrollment: Enrollment): Promise<Enrollment> {

--- a/src/academic/infrastructure/api/MeetingRepositoryImpl.ts
+++ b/src/academic/infrastructure/api/MeetingRepositoryImpl.ts
@@ -3,6 +3,7 @@ import { Meeting } from "@/academic/domain/entities/Meeting";
 import { ApiInstance } from "./Api";
 import { MeetingOutputDto } from "./dto/MeetingDto";
 import { MeetingMapper } from "./mappers/MeetingMapper";
+import { Page } from "@/lib/utils";
 
 export class MeetingRepositoryImpl implements MeetingRepository {
     async create(meeting: Meeting): Promise<Meeting> {
@@ -13,9 +14,19 @@ export class MeetingRepositoryImpl implements MeetingRepository {
         return MeetingMapper.toDomain(res.data);
     }
 
-    async list(): Promise<Meeting[]> {
-        const res = await ApiInstance.get<MeetingOutputDto[]>('/meetings');
-        return res.data.map(MeetingMapper.toDomain);
+    async list(page: number, limit: number, topic?: string): Promise<Page<Meeting>> {
+        const params = new URLSearchParams();
+        params.append('page', page.toString());
+        params.append('limit', limit.toString());
+        if (topic) params.append('topic', topic);
+        const res = await ApiInstance.get<Page<MeetingOutputDto>>(
+            '/meetings',
+            { params }
+        );
+        return {
+            ...res.data,
+            content: res.data.content.map(MeetingMapper.toDomain)
+        };
     }
 
     async update(meeting: Meeting): Promise<Meeting> {

--- a/src/academic/infrastructure/api/PromotionActRepositoryImpl.ts
+++ b/src/academic/infrastructure/api/PromotionActRepositoryImpl.ts
@@ -3,6 +3,7 @@ import { PromotionAct } from "@/academic/domain/entities/PromotionAct";
 import { ApiInstance } from "./Api";
 import { PromotionActOutputDto } from "./dto/PromotionActDto";
 import { PromotionActMapper } from "./mappers/PromotionActMapper";
+import { Page } from "@/lib/utils";
 
 export class PromotionActRepositoryImpl implements PromotionActRepository {
     async create(courseId: string, academicYearId: string, generatedBy: number): Promise<PromotionAct> {
@@ -18,12 +19,20 @@ export class PromotionActRepositoryImpl implements PromotionActRepository {
         return PromotionActMapper.toDomain(res.data);
     }
 
-    async list(courseId: string, academicYearId: string): Promise<PromotionAct[]> {
-        const res = await ApiInstance.get<PromotionActOutputDto[]>(
+    async list(courseId: string, academicYearId: string, page: number, limit: number): Promise<Page<PromotionAct>> {
+        const params = new URLSearchParams();
+        params.append('courseId', courseId);
+        params.append('academicYearId', academicYearId);
+        params.append('page', page.toString());
+        params.append('limit', limit.toString());
+        const res = await ApiInstance.get<Page<PromotionActOutputDto>>(
             '/promotion-acts',
-            { params: { courseId, academicYearId } }
+            { params }
         );
-        return res.data.map(PromotionActMapper.toDomain);
+        return {
+            ...res.data,
+            content: res.data.content.map(PromotionActMapper.toDomain)
+        };
     }
 
     async delete(id: number): Promise<void> {

--- a/src/academic/infrastructure/api/RepresentativeRepositoryImpl.ts
+++ b/src/academic/infrastructure/api/RepresentativeRepositoryImpl.ts
@@ -11,10 +11,11 @@ export class RepresentativeRepositoryImpl implements RepresentativeRepository {
         return RepresentativeMapper.toDomain(res.data);
     }
 
-    async list(page: number, limit: number): Promise<Page<Representative>> {
+    async list(page: number, limit: number, search?: string): Promise<Page<Representative>> {
         const params = new URLSearchParams();
         params.append("page", page.toString());
         params.append("limit", limit.toString());
+        if (search) params.append("search", search);
         const res = await ApiInstance.get<Page<RepresentativeOutputDto>>("/representative", { params });
         return {
             ...res.data,

--- a/src/academic/infrastructure/api/StudentRepositoryImpl.ts
+++ b/src/academic/infrastructure/api/StudentRepositoryImpl.ts
@@ -14,15 +14,13 @@ export class StudentRepositoryImpl implements StudentRepository {
         return StudentMapper.toDomain(res.data);
     }
 
-    async list(page: number, limit: number, uuidParallel?: string): Promise<Page<Student>> {
+    async list(page: number, limit: number, uuidParallel?: string, search?: string): Promise<Page<Student>> {
         const params = new URLSearchParams();
         params.append('page', page.toString());
         params.append('limit', limit.toString());
         if (uuidParallel) params.append('uuidParallel', uuidParallel);
-        const res = await ApiInstance.get<Page<StudentOutputDto>>(
-            '/students',
-            { params }
-        );
+        if (search) params.append('search', search);
+        const res = await ApiInstance.get<Page<StudentOutputDto>>('/students', { params });
         return {
             ...res.data,
             content: res.data.content.map(StudentMapper.toDomain)

--- a/src/academic/infrastructure/api/TeacherAssignmentRepositoryImpl.ts
+++ b/src/academic/infrastructure/api/TeacherAssignmentRepositoryImpl.ts
@@ -3,6 +3,7 @@ import { TeacherAssignment } from "@/academic/domain/entities/TeacherAssignment"
 import { ApiInstance } from "./Api";
 import { TeacherAssignmentOutputDto } from "./dto/TeacherAssignmentDto";
 import { TeacherAssignmentMapper } from "./mappers/TeacherAssignmentMapper";
+import { Page } from "@/lib/utils";
 
 export class TeacherAssignmentRepositoryImpl implements TeacherAssignmentRepository {
     async create(assignment: TeacherAssignment): Promise<TeacherAssignment> {
@@ -19,14 +20,19 @@ export class TeacherAssignmentRepositoryImpl implements TeacherAssignmentReposit
         return res.data ? TeacherAssignmentMapper.toDomain(res.data) : null;
     }
 
-    async list(teacherId?: number, courseId?: number): Promise<TeacherAssignment[]> {
+    async list(page: number, limit: number, teacherId?: number, courseId?: number): Promise<Page<TeacherAssignment>> {
         const params = new URLSearchParams();
+        params.append('page', page.toString());
+        params.append('limit', limit.toString());
         if (teacherId !== undefined) params.append('teacherId', teacherId.toString());
         if (courseId !== undefined) params.append('courseId', courseId.toString());
-        const res = await ApiInstance.get<TeacherAssignmentOutputDto[]>(
+        const res = await ApiInstance.get<Page<TeacherAssignmentOutputDto>>(
             '/teacher-assignments',
             { params }
         );
-        return res.data.map(TeacherAssignmentMapper.toDomain);
+        return {
+            ...res.data,
+            content: res.data.content.map(TeacherAssignmentMapper.toDomain)
+        };
     }
 }

--- a/src/academic/infrastructure/api/TeacherPlanningRepositoryImpl.ts
+++ b/src/academic/infrastructure/api/TeacherPlanningRepositoryImpl.ts
@@ -3,6 +3,7 @@ import { TeacherPlanning } from "@/academic/domain/entities/TeacherPlanning";
 import { ApiInstance } from "./Api";
 import { TeacherPlanningOutputDto } from "./dto/TeacherPlanningDto";
 import { TeacherPlanningMapper } from "./mappers/TeacherPlanningMapper";
+import { Page } from "@/lib/utils";
 
 export class TeacherPlanningRepositoryImpl implements TeacherPlanningRepository {
     async create(planning: TeacherPlanning): Promise<TeacherPlanning> {
@@ -19,15 +20,21 @@ export class TeacherPlanningRepositoryImpl implements TeacherPlanningRepository 
         return res.data ? TeacherPlanningMapper.toDomain(res.data) : null;
     }
 
-    async list(teacherId?: number, subjectId?: number, courseId?: number): Promise<TeacherPlanning[]> {
+    async list(page: number, limit: number, teacherId?: number, subjectId?: number, courseId?: number, topic?: string): Promise<Page<TeacherPlanning>> {
         const params = new URLSearchParams();
+        params.append('page', page.toString());
+        params.append('limit', limit.toString());
         if (teacherId !== undefined) params.append('teacherId', teacherId.toString());
         if (subjectId !== undefined) params.append('subjectId', subjectId.toString());
         if (courseId !== undefined) params.append('courseId', courseId.toString());
-        const res = await ApiInstance.get<TeacherPlanningOutputDto[]>(
+        if (topic) params.append('topic', topic);
+        const res = await ApiInstance.get<Page<TeacherPlanningOutputDto>>(
             '/teacher-plannings',
             { params }
         );
-        return res.data.map(TeacherPlanningMapper.toDomain);
+        return {
+            ...res.data,
+            content: res.data.content.map(TeacherPlanningMapper.toDomain)
+        };
     }
 }

--- a/src/academic/presentation/ui/Assessment/Edit/AssessmentEditContainer.tsx
+++ b/src/academic/presentation/ui/Assessment/Edit/AssessmentEditContainer.tsx
@@ -17,7 +17,7 @@ export const AssessmentEditContainer = () => {
 
   const fetchAssessment = useCallback(async () => {
     if (!id) return;
-    const res = await listUseCase.execute(new ListAssessmentsCommand());
+    const res = await listUseCase.execute(new ListAssessmentsCommand(1, 1000));
     res.ifRight(assessments => {
       const assessment = assessments?.find(a => a.id === Number(id));
       if (!assessment) return;

--- a/src/academic/presentation/ui/Assessment/List/AssessmentListContainer.tsx
+++ b/src/academic/presentation/ui/Assessment/List/AssessmentListContainer.tsx
@@ -4,34 +4,61 @@ import { AssessmentListPresenter } from "./AssessmentListPresenter";
 import { useInjection } from "inversify-react";
 import { useCallback, useEffect, useState } from "react";
 import { Assessment } from "@/academic/domain/entities/Assessment";
+import { Page } from "@/lib/utils";
+import { toast } from "@/hooks/use-toast";
+import { useNavigate, useSearchParams } from "react-router";
 
 export const AssessmentListContainer = () => {
   const listUseCase = useInjection<ListAssessmentsUseCase>(ASSESSMENT_SYMBOLS.LIST_USE_CASE);
-  const [assessments, setAssessments] = useState<Assessment[]>([]);
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const page = Number(searchParams.get("page")) || 1;
+  const filter = searchParams.get("filter") || "";
+
+  const [assessments, setAssessments] = useState<Page<Assessment>>({
+    content: [],
+    page: 0,
+    size: 10,
+    total: 0,
+    totalPage: 0,
+  });
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [searchTerm, setSearchTerm] = useState("");
 
   const fetchData = useCallback(async () => {
     setLoading(true);
-    setError(null);
-    const res = await listUseCase.execute(new ListAssessmentsCommand());
-    res.ifRight(data => setAssessments(data ?? [])).ifLeft(failures => setError(failures.map(f => f.message).join(", ")));
+    const res = await listUseCase.execute(new ListAssessmentsCommand(page, 10, filter));
+    res
+      .ifRight(data => {
+        if (data) setAssessments(data);
+      })
+      .ifLeft(failures =>
+        toast({
+          title: "Error",
+          description: failures.map(f => f.message).join(", "),
+          variant: "destructive",
+        })
+      );
     setLoading(false);
-  }, [listUseCase]);
+  }, [listUseCase, page, filter]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
-  const filtered = assessments.filter(a => a.studentId.toString().includes(searchTerm));
+  const handleSearchChange = (term: string) => {
+    navigate({ pathname: "/evaluaciones", search: `?page=1&filter=${term}` });
+  };
+
+  const handleAddAssessment = () => {
+    navigate("/evaluaciones/nueva");
+  };
 
   return (
     <AssessmentListPresenter
-      assessments={filtered}
+      assessments={assessments}
       loading={loading}
-      error={error}
-      searchTerm={searchTerm}
-      onSearchChange={setSearchTerm}
-      onAddAssessment={() => {}}
+      error={null}
+      searchTerm={filter}
+      onSearchChange={handleSearchChange}
+      onAddAssessment={handleAddAssessment}
     />
   );
 };

--- a/src/academic/presentation/ui/Assessment/List/AssessmentListPresenter.tsx
+++ b/src/academic/presentation/ui/Assessment/List/AssessmentListPresenter.tsx
@@ -3,12 +3,14 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, Plus } from "lucide-react";
+import { Search, Plus, FileX } from "lucide-react";
 import { Assessment } from "@/academic/domain/entities/Assessment";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Pagination, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Page } from "@/lib/utils";
 
 interface Props {
-  assessments: Assessment[];
+  assessments: Page<Assessment>;
   loading: boolean;
   error: string | null;
   searchTerm: string;
@@ -30,12 +32,17 @@ export const AssessmentListPresenter = ({ assessments, loading, error, searchTer
       <CardContent>
         <div className="flex items-center gap-2 mb-6">
           <Search className="h-4 w-4 text-muted-foreground" />
-          <Input placeholder="Buscar por estudiante" value={searchTerm} onChange={e => onSearchChange(e.target.value)} className="max-w-sm" />
+          <Input
+            placeholder="Buscar por estudiante"
+            value={searchTerm}
+            onChange={e => onSearchChange(e.target.value)}
+            className="max-w-sm"
+          />
         </div>
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {loading && <Skeleton role="status" className="h-24 w-full col-span-full" />}
           {error && <div className="text-destructive text-center col-span-full">{error}</div>}
-          {assessments.map(a => (
+          {assessments.content.map(a => (
             <Card key={a.id} className="hover:shadow-md transition-shadow">
               <CardContent className="p-4">
                 <p className="font-semibold">Estudiante: {a.studentId}</p>
@@ -45,7 +52,36 @@ export const AssessmentListPresenter = ({ assessments, loading, error, searchTer
             </Card>
           ))}
         </div>
-        {assessments.length === 0 && !loading && !error && <div className="text-center py-8 text-muted-foreground">No se encontraron evaluaciones</div>}
+        {assessments.content.length === 0 && !loading && !error && (
+          <div className="col-span-3 text-center py-8 text-muted-foreground w-full flex flex-col items-center space-y-4">
+            <FileX className="h-12 w-12 text-muted-foreground" />
+            <p className="text-lg font-medium">
+              {searchTerm
+                ? `No encontramos resultados para "${searchTerm}".`
+                : "No hay evaluaciones registradas aún."}
+            </p>
+            {!searchTerm && <Button onClick={onAddAssessment}>Nueva</Button>}
+          </div>
+        )}
+
+        <Pagination className="col-span-full justify-center">
+          <PaginationPrevious className="bg-background" />
+          {assessments.totalPage > 1 &&
+            Array.from({ length: assessments.totalPage }).map((_, index) => (
+              <PaginationLink
+                key={`page-${index + 1}`}
+                href={`/evaluaciones?page=${index + 1}${searchTerm ? `&filter=${searchTerm}` : ""}`}
+                isActive={index === assessments.page}
+                className="bg-background"
+              >
+                {index + 1}
+              </PaginationLink>
+            ))}
+          <PaginationNext className="bg-background" />
+        </Pagination>
+        <div className="col-span-full text-center text-sm text-muted-foreground">
+          Página {assessments.page} de {assessments.totalPage} - Total de evaluaciones: {assessments.total}
+        </div>
       </CardContent>
     </Card>
   </div>

--- a/src/academic/presentation/ui/Attendance/Edit/AttendanceEditContainer.tsx
+++ b/src/academic/presentation/ui/Attendance/Edit/AttendanceEditContainer.tsx
@@ -18,18 +18,25 @@ export const AttendanceEditContainer = () => {
 
   const fetchAttendance = useCallback(async () => {
     if (!id) return;
-    const res = await listUseCase.execute(new ListAttendanceCommand());
-    res.ifRight(list => {
-      const attendance = list?.find(a => a.id === Number(id));
-      if (attendance) {
-        setValue("id", attendance.id);
-        setValue("status", attendance.status);
-        (setValue as any)("studentId", attendance.studentId);
-        (setValue as any)("date", attendance.date);
-      }
-    }).ifLeft(failures => {
-      toast({ title: "Error", description: failures.map(f=>f.message).join(", "), duration:5000, variant:"destructive" });
-    });
+    const res = await listUseCase.execute(new ListAttendanceCommand(1, 1000));
+    res
+      .ifRight(list => {
+        const attendance = list?.content.find(a => a.id === Number(id));
+        if (attendance) {
+          setValue("id", attendance.id);
+          setValue("status", attendance.status);
+          (setValue as any)("studentId", attendance.studentId);
+          (setValue as any)("date", attendance.date);
+        }
+      })
+      .ifLeft(failures => {
+        toast({
+          title: "Error",
+          description: failures.map(f => f.message).join(", "),
+          duration: 5000,
+          variant: "destructive",
+        });
+      });
   }, [id, listUseCase, setValue]);
 
   useEffect(() => {

--- a/src/academic/presentation/ui/Attendance/List/AttendanceListPresenter.tsx
+++ b/src/academic/presentation/ui/Attendance/List/AttendanceListPresenter.tsx
@@ -3,12 +3,14 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, Plus } from "lucide-react";
+import { Search, Plus, UserX } from "lucide-react";
 import { Attendance } from "@/academic/domain/entities/Attendance";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Pagination, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Page } from "@/lib/utils";
 
 interface Props {
-  attendances: Attendance[];
+  attendances: Page<Attendance>;
   loading: boolean;
   error: string | null;
   searchTerm: string;
@@ -30,12 +32,17 @@ export const AttendanceListPresenter = ({ attendances, loading, error, searchTer
       <CardContent>
         <div className="flex items-center gap-2 mb-6">
           <Search className="h-4 w-4 text-muted-foreground" />
-          <Input placeholder="Buscar por ID de estudiante" value={searchTerm} onChange={e=>onSearchChange(e.target.value)} className="max-w-sm" />
+          <Input
+            placeholder="Buscar por ID de estudiante"
+            value={searchTerm}
+            onChange={e => onSearchChange(e.target.value)}
+            className="max-w-sm"
+          />
         </div>
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {loading && <Skeleton role="status" className="h-24 w-full col-span-full" />}
           {error && <div className="text-destructive text-center col-span-full">{error}</div>}
-          {attendances.map(a => (
+          {attendances.content.map(a => (
             <Card key={a.id} className="hover:shadow-md transition-shadow">
               <CardContent className="p-4">
                 <div className="text-sm font-medium">Estudiante: {a.studentId}</div>
@@ -45,9 +52,35 @@ export const AttendanceListPresenter = ({ attendances, loading, error, searchTer
             </Card>
           ))}
         </div>
-        {attendances.length === 0 && !loading && !error && (
-          <div className="text-center py-8 text-muted-foreground">No se encontraron asistencias</div>
+        {attendances.content.length === 0 && !loading && !error && (
+          <div className="col-span-3 text-center py-8 text-muted-foreground w-full flex flex-col items-center space-y-4">
+            <UserX className="h-12 w-12 text-muted-foreground" />
+            <p className="text-lg font-medium">
+              {searchTerm
+                ? `No encontramos resultados para "${searchTerm}".`
+                : "No hay asistencias registradas aún."}
+            </p>
+            {!searchTerm && <Button onClick={onAdd}>Registrar</Button>}
+          </div>
         )}
+
+        <Pagination className="col-span-full justify-center">
+          <PaginationPrevious className="bg-background" />
+          {attendances.total > 1 && Array.from({ length: attendances.totalPage }).map((_, index) => (
+            <PaginationLink
+              key={`page-${index + 1}`}
+              href={`/asistencias?page=${index + 1}${searchTerm ? `&filter=${searchTerm}` : ""}`}
+              isActive={index === attendances.page}
+              className="bg-background"
+            >
+              {index + 1}
+            </PaginationLink>
+          ))}
+          <PaginationNext className="bg-background" />
+        </Pagination>
+        <div className="col-span-full text-center text-sm text-muted-foreground">
+          Página {attendances.page} de {attendances.totalPage} - Total de asistencias: {attendances.total}
+        </div>
       </CardContent>
     </Card>
   </div>

--- a/src/academic/presentation/ui/BehaviorReport/Edit/BehaviorReportEditContainer.tsx
+++ b/src/academic/presentation/ui/BehaviorReport/Edit/BehaviorReportEditContainer.tsx
@@ -18,9 +18,9 @@ export const BehaviorReportEditContainer = () => {
 
   const fetchReport = useCallback(async () => {
     if (!id) return;
-    const res = await listUseCase.execute(new ListBehaviorReportsCommand());
-    res.ifRight((reports) => {
-      const report = reports?.find(r => r.id === Number(id));
+    const res = await listUseCase.execute(new ListBehaviorReportsCommand(1, 1000));
+    res.ifRight((page) => {
+      const report = page?.content.find(r => r.id === Number(id));
       if (!report) return;
       setValue("id", report.id);
       setValue("description", report.description);

--- a/src/academic/presentation/ui/BehaviorReport/List/BehaviorReportListPresenter.tsx
+++ b/src/academic/presentation/ui/BehaviorReport/List/BehaviorReportListPresenter.tsx
@@ -3,12 +3,14 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, Plus } from "lucide-react";
+import { Search, Plus, UserX } from "lucide-react";
 import { BehaviorReport } from "@/academic/domain/entities/BehaviorReport";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Pagination, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Page } from "@/lib/utils";
 
 interface Props {
-  reports: BehaviorReport[];
+  reports: Page<BehaviorReport>;
   loading: boolean;
   error: string | null;
   searchTerm: string;
@@ -48,11 +50,11 @@ export function BehaviorReportListPresenter({
           </div>
 
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {loading && <Skeleton className="h-24 w-full col-span-full" />}
+            {loading && <Skeleton role="status" className="h-24 w-full col-span-full" />}
             {error && (
               <div className="text-destructive text-center col-span-full">{error}</div>
             )}
-            {reports.map((report) => (
+            {reports.content.map(report => (
               <Card key={report.id} className="hover:shadow-md transition-shadow">
                 <CardContent className="p-4">
                   <p className="font-semibold text-sm">Estudiante: {report.studentId}</p>
@@ -64,11 +66,35 @@ export function BehaviorReportListPresenter({
             ))}
           </div>
 
-          {reports.length === 0 && !loading && !error && (
-            <div className="text-center py-8 text-muted-foreground">
-              No se encontraron reportes
+          {reports.content.length === 0 && !loading && !error && (
+            <div className="col-span-3 text-center py-8 text-muted-foreground w-full flex flex-col items-center space-y-4">
+              <UserX className="h-12 w-12 text-muted-foreground" />
+              <p className="text-lg font-medium">
+                {searchTerm
+                  ? `No encontramos resultados para "${searchTerm}".`
+                  : "No hay reportes registrados aún."}
+              </p>
+              {!searchTerm && <Button onClick={onAddReport}>Registrar reporte</Button>}
             </div>
           )}
+
+          <Pagination className="col-span-full justify-center">
+            <PaginationPrevious className="bg-background" />
+            {reports.total > 1 && Array.from({ length: reports.totalPage }).map((_, index) => (
+              <PaginationLink
+                key={`page-${index + 1}`}
+                href={`/reportes-conducta?page=${index + 1}${searchTerm ? `&filter=${searchTerm}` : ""}`}
+                isActive={index === reports.page}
+                className="bg-background"
+              >
+                {index + 1}
+              </PaginationLink>
+            ))}
+            <PaginationNext className="bg-background" />
+          </Pagination>
+          <div className="col-span-full text-center text-sm text-muted-foreground">
+            Página {reports.page} de {reports.totalPage} - Total de reportes: {reports.total}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/academic/presentation/ui/Enrollment/Edit/EnrollmentEditContainer.tsx
+++ b/src/academic/presentation/ui/Enrollment/Edit/EnrollmentEditContainer.tsx
@@ -18,17 +18,24 @@ export const EnrollmentEditContainer = () => {
 
   const fetchEnrollment = useCallback(async () => {
     if (!id) return;
-    const res = await listUseCase.execute(new ListEnrollmentsCommand());
-    res.ifRight(list => {
-      const enrollment = list?.find(e => e.id === Number(id));
-      if (enrollment) {
-        setValue("id", enrollment.id);
-        setValue("courseId", enrollment.courseId);
-        (setValue as any)("studentId", enrollment.studentId);
-      }
-    }).ifLeft(failures => {
-      toast({ title: "Error", description: failures.map(f=>f.message).join(", "), duration:5000, variant:"destructive" });
-    });
+    const res = await listUseCase.execute(new ListEnrollmentsCommand(1, 1000));
+    res
+      .ifRight(list => {
+        const enrollment = list?.content.find(e => e.id === Number(id));
+        if (enrollment) {
+          setValue("id", enrollment.id);
+          setValue("courseId", enrollment.courseId);
+          (setValue as any)("studentId", enrollment.studentId);
+        }
+      })
+      .ifLeft(failures => {
+        toast({
+          title: "Error",
+          description: failures.map(f => f.message).join(", "),
+          duration: 5000,
+          variant: "destructive",
+        });
+      });
   }, [id, listUseCase, setValue]);
 
   useEffect(() => { fetchEnrollment(); }, [fetchEnrollment]);

--- a/src/academic/presentation/ui/Enrollment/List/EnrollmentListContainer.tsx
+++ b/src/academic/presentation/ui/Enrollment/List/EnrollmentListContainer.tsx
@@ -4,36 +4,54 @@ import { useInjection } from "inversify-react";
 import { ENROLLMENT_SYMBOLS } from "@/academic/domain/symbols/Enrollment";
 import { useCallback, useEffect, useState } from "react";
 import { Enrollment } from "@/academic/domain/entities/Enrollment";
+import { Page } from "@/lib/utils";
+import { toast } from "@/hooks/use-toast";
+import { useNavigate, useSearchParams } from "react-router";
 
 export const EnrollmentListContainer = () => {
   const listUseCase = useInjection<ListEnrollmentsUseCase>(ENROLLMENT_SYMBOLS.LIST_USE_CASE);
-  const [enrollments, setEnrollments] = useState<Enrollment[]>([]);
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const page = Number(searchParams.get("page")) || 1;
+  const filter = searchParams.get("filter") || "";
+
+  const [enrollments, setEnrollments] = useState<Page<Enrollment>>({
+    content: [],
+    page: 0,
+    size: 10,
+    total: 0,
+    totalPage: 0,
+  });
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [searchTerm, setSearchTerm] = useState("");
 
   const fetchEnrollments = useCallback(async () => {
     setLoading(true);
-    setError(null);
-    const res = await listUseCase.execute(new ListEnrollmentsCommand());
-    res.ifRight(data => { setEnrollments(data ?? []); }).ifLeft(failures => { setError(failures.map(f=>f.message).join(", ")); });
+    const res = await listUseCase.execute(new ListEnrollmentsCommand(page, 10, filter));
+    res
+      .ifRight(data => {
+        if (data) setEnrollments(data);
+      })
+      .ifLeft(failures => {
+        const msg = failures.map(f => f.message).join(", ");
+        toast({ title: "Error", description: msg, variant: "destructive" });
+      });
     setLoading(false);
-  }, [listUseCase]);
+  }, [listUseCase, page, filter]);
 
   useEffect(() => { fetchEnrollments(); }, [fetchEnrollments]);
 
-  const handleSearchChange = (term: string) => setSearchTerm(term);
-
-  const filtered = enrollments.filter(e => e.courseId.toLowerCase().includes(searchTerm.toLowerCase()));
+  const handleSearchChange = (term: string) => {
+    navigate({ pathname: "/matriculas", search: `?page=1&filter=${term}` });
+  };
 
   return (
     <EnrollmentListPresenter
-      enrollments={filtered}
+      enrollments={enrollments}
       loading={loading}
-      error={error}
-      searchTerm={searchTerm}
+      error={null}
+      searchTerm={filter}
       onSearchChange={handleSearchChange}
-      onAdd={() => {}}
+      onAdd={() => navigate("/matriculas/nuevo")}
     />
   );
 };

--- a/src/academic/presentation/ui/Enrollment/List/EnrollmentListPresenter.tsx
+++ b/src/academic/presentation/ui/Enrollment/List/EnrollmentListPresenter.tsx
@@ -3,12 +3,14 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, Plus } from "lucide-react";
+import { Search, Plus, UserX } from "lucide-react";
 import { Enrollment } from "@/academic/domain/entities/Enrollment";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Pagination, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Page } from "@/lib/utils";
 
 interface Props {
-  enrollments: Enrollment[];
+  enrollments: Page<Enrollment>;
   loading: boolean;
   error: string | null;
   searchTerm: string;
@@ -30,12 +32,17 @@ export const EnrollmentListPresenter = ({ enrollments, loading, error, searchTer
       <CardContent>
         <div className="flex items-center gap-2 mb-6">
           <Search className="h-4 w-4 text-muted-foreground" />
-          <Input placeholder="Buscar por curso" value={searchTerm} onChange={e=>onSearchChange(e.target.value)} className="max-w-sm" />
+          <Input
+            placeholder="Buscar por curso"
+            value={searchTerm}
+            onChange={e => onSearchChange(e.target.value)}
+            className="max-w-sm"
+          />
         </div>
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {loading && <Skeleton role="status" className="h-24 w-full col-span-full" />}
           {error && <div className="text-destructive text-center col-span-full">{error}</div>}
-          {enrollments.map(e => (
+          {enrollments.content.map(e => (
             <Card key={e.id} className="hover:shadow-md transition-shadow">
               <CardContent className="p-4">
                 <div className="text-sm font-medium">Estudiante: {e.studentId}</div>
@@ -44,9 +51,37 @@ export const EnrollmentListPresenter = ({ enrollments, loading, error, searchTer
             </Card>
           ))}
         </div>
-        {enrollments.length === 0 && !loading && !error && (
-          <div className="text-center py-8 text-muted-foreground">No se encontraron matrículas</div>
+        {enrollments.content.length === 0 && !loading && !error && (
+          <div className="col-span-3 text-center py-8 text-muted-foreground w-full flex flex-col items-center space-y-4">
+            <UserX className="h-12 w-12 text-muted-foreground" />
+            <p className="text-lg font-medium">
+              {searchTerm
+                ? `No encontramos resultados para "${searchTerm}".`
+                : "No hay matrículas registradas aún."}
+            </p>
+            {!searchTerm && (
+              <Button onClick={onAdd}>Registrar</Button>
+            )}
+          </div>
         )}
+
+        <Pagination className="col-span-full justify-center">
+          <PaginationPrevious className="bg-background" />
+          {enrollments.total > 1 && Array.from({ length: enrollments.totalPage }).map((_, index) => (
+            <PaginationLink
+              key={`page-${index + 1}`}
+              href={`/matriculas?page=${index + 1}${searchTerm ? `&filter=${searchTerm}` : ""}`}
+              isActive={index === enrollments.page}
+              className="bg-background"
+            >
+              {index + 1}
+            </PaginationLink>
+          ))}
+          <PaginationNext className="bg-background" />
+        </Pagination>
+        <div className="col-span-full text-center text-sm text-muted-foreground">
+          Página {enrollments.page} de {enrollments.totalPage} - Total de matrículas: {enrollments.total}
+        </div>
       </CardContent>
     </Card>
   </div>

--- a/src/academic/presentation/ui/Meeting/Edit/MeetingEditContainer.tsx
+++ b/src/academic/presentation/ui/Meeting/Edit/MeetingEditContainer.tsx
@@ -17,7 +17,7 @@ export const MeetingEditContainer = () => {
 
   const fetchMeeting = useCallback(async () => {
     if (!id) return;
-    const res = await listUseCase.execute(new ListMeetingsCommand());
+    const res = await listUseCase.execute(new ListMeetingsCommand(1, 1000));
     res.ifRight(meetings => {
       const meeting = meetings?.find(m => m.id === Number(id));
       if (!meeting) return;

--- a/src/academic/presentation/ui/Meeting/List/MeetingListContainer.tsx
+++ b/src/academic/presentation/ui/Meeting/List/MeetingListContainer.tsx
@@ -4,34 +4,61 @@ import { MEETING_SYMBOLS } from "@/academic/domain/symbols/Meeting";
 import { useInjection } from "inversify-react";
 import { useCallback, useEffect, useState } from "react";
 import { Meeting } from "@/academic/domain/entities/Meeting";
+import { Page } from "@/lib/utils";
+import { toast } from "@/hooks/use-toast";
+import { useNavigate, useSearchParams } from "react-router";
 
 export const MeetingListContainer = () => {
   const listUseCase = useInjection<ListMeetingsUseCase>(MEETING_SYMBOLS.LIST_USE_CASE);
-  const [meetings, setMeetings] = useState<Meeting[]>([]);
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const page = Number(searchParams.get("page")) || 1;
+  const filter = searchParams.get("filter") || "";
+
+  const [meetings, setMeetings] = useState<Page<Meeting>>({
+    content: [],
+    page: 0,
+    size: 10,
+    total: 0,
+    totalPage: 0,
+  });
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [searchTerm, setSearchTerm] = useState("");
 
   const fetchData = useCallback(async () => {
     setLoading(true);
-    setError(null);
-    const res = await listUseCase.execute(new ListMeetingsCommand());
-    res.ifRight(data => setMeetings(data ?? [])).ifLeft(f => setError(f.map(x => x.message).join(", ")));
+    const res = await listUseCase.execute(new ListMeetingsCommand(page, 10, filter));
+    res
+      .ifRight(data => {
+        if (data) setMeetings(data);
+      })
+      .ifLeft(f =>
+        toast({
+          title: "Error",
+          description: f.map(x => x.message).join(", "),
+          variant: "destructive",
+        })
+      );
     setLoading(false);
-  }, [listUseCase]);
+  }, [listUseCase, page, filter]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
-  const filtered = meetings.filter(m => m.topic.toLowerCase().includes(searchTerm.toLowerCase()));
+  const handleSearchChange = (term: string) => {
+    navigate({ pathname: "/reuniones", search: `?page=1&filter=${term}` });
+  };
+
+  const handleAddMeeting = () => {
+    navigate("/reuniones/nueva");
+  };
 
   return (
     <MeetingListPresenter
-      meetings={filtered}
+      meetings={meetings}
       loading={loading}
-      error={error}
-      searchTerm={searchTerm}
-      onSearchChange={setSearchTerm}
-      onAddMeeting={() => {}}
+      error={null}
+      searchTerm={filter}
+      onSearchChange={handleSearchChange}
+      onAddMeeting={handleAddMeeting}
     />
   );
 };

--- a/src/academic/presentation/ui/Meeting/List/MeetingListPresenter.tsx
+++ b/src/academic/presentation/ui/Meeting/List/MeetingListPresenter.tsx
@@ -3,12 +3,14 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, Plus } from "lucide-react";
+import { Search, Plus, CalendarX } from "lucide-react";
 import { Meeting } from "@/academic/domain/entities/Meeting";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Pagination, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Page } from "@/lib/utils";
 
 interface Props {
-  meetings: Meeting[];
+  meetings: Page<Meeting>;
   loading: boolean;
   error: string | null;
   searchTerm: string;
@@ -30,12 +32,17 @@ export const MeetingListPresenter = ({ meetings, loading, error, searchTerm, onS
       <CardContent>
         <div className="flex items-center gap-2 mb-6">
           <Search className="h-4 w-4 text-muted-foreground" />
-          <Input placeholder="Buscar por tema" value={searchTerm} onChange={e => onSearchChange(e.target.value)} className="max-w-sm" />
+          <Input
+            placeholder="Buscar por tema"
+            value={searchTerm}
+            onChange={e => onSearchChange(e.target.value)}
+            className="max-w-sm"
+          />
         </div>
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {loading && <Skeleton role="status" className="h-24 w-full col-span-full" />}
           {error && <div className="text-destructive text-center col-span-full">{error}</div>}
-          {meetings.map(m => (
+          {meetings.content.map(m => (
             <Card key={m.id} className="hover:shadow-md transition-shadow">
               <CardContent className="p-4">
                 <p className="font-semibold">{m.topic}</p>
@@ -44,7 +51,36 @@ export const MeetingListPresenter = ({ meetings, loading, error, searchTerm, onS
             </Card>
           ))}
         </div>
-        {meetings.length === 0 && !loading && !error && <div className="text-center py-8 text-muted-foreground">No se encontraron reuniones</div>}
+        {meetings.content.length === 0 && !loading && !error && (
+          <div className="col-span-3 text-center py-8 text-muted-foreground w-full flex flex-col items-center space-y-4">
+            <CalendarX className="h-12 w-12 text-muted-foreground" />
+            <p className="text-lg font-medium">
+              {searchTerm
+                ? `No encontramos resultados para "${searchTerm}".`
+                : "No hay reuniones registradas aún."}
+            </p>
+            {!searchTerm && <Button onClick={onAddMeeting}>Nueva</Button>}
+          </div>
+        )}
+
+        <Pagination className="col-span-full justify-center">
+          <PaginationPrevious className="bg-background" />
+          {meetings.totalPage > 1 &&
+            Array.from({ length: meetings.totalPage }).map((_, index) => (
+              <PaginationLink
+                key={`page-${index + 1}`}
+                href={`/reuniones?page=${index + 1}${searchTerm ? `&filter=${searchTerm}` : ""}`}
+                isActive={index === meetings.page}
+                className="bg-background"
+              >
+                {index + 1}
+              </PaginationLink>
+            ))}
+          <PaginationNext className="bg-background" />
+        </Pagination>
+        <div className="col-span-full text-center text-sm text-muted-foreground">
+          Página {meetings.page} de {meetings.totalPage} - Total de reuniones: {meetings.total}
+        </div>
       </CardContent>
     </Card>
   </div>

--- a/src/academic/presentation/ui/PromotionAct/List/PromotionActListContainer.tsx
+++ b/src/academic/presentation/ui/PromotionAct/List/PromotionActListContainer.tsx
@@ -4,37 +4,69 @@ import { PromotionActListPresenter } from "./PromotionActListPresenter";
 import { useInjection } from "inversify-react";
 import { useCallback, useEffect, useState } from "react";
 import { PromotionAct } from "@/academic/domain/entities/PromotionAct";
+import { Page } from "@/lib/utils";
+import { toast } from "@/hooks/use-toast";
+import { useNavigate, useSearchParams } from "react-router";
 
 export const PromotionActListContainer = () => {
   const listUseCase = useInjection<ListPromotionActsUseCase>(PROMOTION_ACT_SYMBOLS.LIST_USE_CASE);
-  const [acts, setActs] = useState<PromotionAct[]>([]);
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const page = Number(searchParams.get("page")) || 1;
+  const initialCourse = searchParams.get("courseId") || "";
+  const initialYear = searchParams.get("yearId") || "";
+
+  const [acts, setActs] = useState<Page<PromotionAct>>({
+    content: [],
+    page: 0,
+    size: 10,
+    total: 0,
+    totalPage: 0,
+  });
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [courseId, setCourseId] = useState("");
-  const [yearId, setYearId] = useState("");
+  const [courseId, setCourseId] = useState(initialCourse);
+  const [yearId, setYearId] = useState(initialYear);
 
   const fetchData = useCallback(async () => {
     if (!courseId || !yearId) return;
     setLoading(true);
-    setError(null);
-    const res = await listUseCase.execute(new ListPromotionActsCommand(courseId, yearId));
-    res.ifRight(data => setActs(data ?? [])).ifLeft(f => setError(f.map(x => x.message).join(", ")));
+    const res = await listUseCase.execute(new ListPromotionActsCommand(courseId, yearId, page, 10));
+    res
+      .ifRight(data => {
+        if (data) setActs(data);
+      })
+      .ifLeft(f =>
+        toast({
+          title: "Error",
+          description: f.map(x => x.message).join(", "),
+          variant: "destructive",
+        })
+      );
     setLoading(false);
-  }, [listUseCase, courseId, yearId]);
+  }, [listUseCase, courseId, yearId, page]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
+
+  const handleSearch = () => {
+    if (!courseId || !yearId) return;
+    navigate({ pathname: "/actas-promocion", search: `?page=1&courseId=${courseId}&yearId=${yearId}` });
+  };
+
+  const handleAddAct = () => {
+    navigate("/actas-promocion/nueva");
+  };
 
   return (
     <PromotionActListPresenter
       acts={acts}
       loading={loading}
-      error={error}
+      error={null}
       courseId={courseId}
       yearId={yearId}
       onCourseChange={setCourseId}
       onYearChange={setYearId}
-      onSearch={fetchData}
-      onAddAct={() => {}}
+      onSearch={handleSearch}
+      onAddAct={handleAddAct}
     />
   );
 };

--- a/src/academic/presentation/ui/PromotionAct/List/PromotionActListPresenter.tsx
+++ b/src/academic/presentation/ui/PromotionAct/List/PromotionActListPresenter.tsx
@@ -5,10 +5,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PromotionAct } from "@/academic/domain/entities/PromotionAct";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Plus } from "lucide-react";
+import { Plus, FileX } from "lucide-react";
+import { Pagination, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Page } from "@/lib/utils";
 
 interface Props {
-  acts: PromotionAct[];
+  acts: Page<PromotionAct>;
   loading: boolean;
   error: string | null;
   courseId: string;
@@ -35,9 +37,9 @@ export const PromotionActListPresenter = ({ acts, loading, error, courseId, year
           <Button onClick={onSearch}>Buscar</Button>
         </div>
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {loading && <Skeleton role="status" className="h-24 w-full col-span-full" />}
           {error && <div className="text-destructive text-center col-span-full">{error}</div>}
-          {acts.map(a => (
+          {acts.content.map(a => (
             <Card key={a.id} className="hover:shadow-md transition-shadow">
               <CardContent className="p-4">
                 <p className="font-semibold">Curso: {a.courseId}</p>
@@ -47,7 +49,32 @@ export const PromotionActListPresenter = ({ acts, loading, error, courseId, year
             </Card>
           ))}
         </div>
-        {acts.length === 0 && !loading && !error && <div className="text-center py-8 text-muted-foreground">No se encontraron actas</div>}
+        {acts.content.length === 0 && !loading && !error && (
+          <div className="col-span-3 text-center py-8 text-muted-foreground w-full flex flex-col items-center space-y-4">
+            <FileX className="h-12 w-12 text-muted-foreground" />
+            <p className="text-lg font-medium">No se encontraron actas</p>
+            {!courseId || !yearId ? null : <Button onClick={onAddAct}>Nueva</Button>}
+          </div>
+        )}
+
+        <Pagination className="col-span-full justify-center">
+          <PaginationPrevious className="bg-background" />
+          {acts.totalPage > 1 &&
+            Array.from({ length: acts.totalPage }).map((_, index) => (
+              <PaginationLink
+                key={`page-${index + 1}`}
+                href={`/actas-promocion?page=${index + 1}&courseId=${courseId}&yearId=${yearId}`}
+                isActive={index === acts.page}
+                className="bg-background"
+              >
+                {index + 1}
+              </PaginationLink>
+            ))}
+          <PaginationNext className="bg-background" />
+        </Pagination>
+        <div className="col-span-full text-center text-sm text-muted-foreground">
+          Página {acts.page} de {acts.totalPage} - Total de actas: {acts.total}
+        </div>
       </CardContent>
     </Card>
   </div>

--- a/src/academic/presentation/ui/Representative/List/RepresentativeListContainer.tsx
+++ b/src/academic/presentation/ui/Representative/List/RepresentativeListContainer.tsx
@@ -28,7 +28,7 @@ export const RepresentativeListContainer = () => {
 
     const fetchRepresentatives = useCallback(async () => {
         setLoading(true);
-        const res = await listUseCase.execute(new ListRepresentativesCommand(page, 10));
+        const res = await listUseCase.execute(new ListRepresentativesCommand(page, 10, filter));
         res
             .ifRight(data => {
                 if (data) setRepresentatives(data);
@@ -41,7 +41,7 @@ export const RepresentativeListContainer = () => {
                 });
             });
         setLoading(false);
-    }, [listUseCase, page]);
+    }, [listUseCase, page, filter]);
 
     useEffect(() => {
         fetchRepresentatives();
@@ -51,15 +51,9 @@ export const RepresentativeListContainer = () => {
         navigate({ pathname: "/representantes", search: `?page=1&filter=${term}` });
     };
 
-    const filteredContent = representatives.content.filter(r =>
-        `${r.firstName} ${r.lastName}`.toLowerCase().includes(filter.toLowerCase())
-    );
-
-    const data = { ...representatives, content: filteredContent };
-
     return (
         <RepresentativeListPresenter
-            representatives={data}
+            representatives={representatives}
             loading={loading}
             error={null}
             onAddRepresentative={() => navigate("/representantes/nuevo")}

--- a/src/academic/presentation/ui/Representative/List/RepresentativeListPresenter.tsx
+++ b/src/academic/presentation/ui/Representative/List/RepresentativeListPresenter.tsx
@@ -101,7 +101,7 @@ export function RepresentativeListPresenter({
                         {representatives.total > 1 && Array.from({ length: representatives.totalPage }).map((_, index) => (
                             <PaginationLink
                                 key={`page-${index + 1}`}
-                                href={`/representantes?page=${index + 1}`}
+                                href={`/representantes?page=${index + 1}${searchTerm ? `&filter=${searchTerm}` : ""}`}
                                 isActive={index === representatives.page}
                                 className="bg-background"
                             >

--- a/src/academic/presentation/ui/Student/List/StudentListContainer.tsx
+++ b/src/academic/presentation/ui/Student/List/StudentListContainer.tsx
@@ -27,7 +27,7 @@ export const StudentListContainer = () => {
 
     const fetchStudents = useCallback(async () => {
         setLoading(true);
-        const res = await listUseCase.execute(new ListStudentsCommand(page, 10));
+        const res = await listUseCase.execute(new ListStudentsCommand(page, 10, undefined, filter));
         res.ifRight(data => {
             if (data) setStudents(data);
         }).ifLeft(failures => {
@@ -39,7 +39,7 @@ export const StudentListContainer = () => {
             });
         });
         setLoading(false);
-    }, [listUseCase, page]);
+    }, [listUseCase, page, filter]);
 
     useEffect(() => {
         fetchStudents();
@@ -49,15 +49,9 @@ export const StudentListContainer = () => {
         navigate({ pathname: "/estudiantes", search: `?page=1&filter=${term}` });
     };
 
-    const filteredContent = students.content.filter(s =>
-        `${s.firstName} ${s.lastName}`.toLowerCase().includes(filter.toLowerCase())
-    );
-
-    const data = { ...students, content: filteredContent };
-
     return (
         <StudentListPresenter
-            students={data}
+            students={students}
             loading={loading}
             error={null}
             onAddStudent={() => navigate("/estudiantes/nuevo")}

--- a/src/academic/presentation/ui/Student/List/StudentListPresenter.tsx
+++ b/src/academic/presentation/ui/Student/List/StudentListPresenter.tsx
@@ -104,7 +104,7 @@ export function StudentListPresenter({
                         {students.total > 1 && Array.from({ length: students.totalPage }).map((_, index) => (
                             <PaginationLink
                                 key={`page-${index + 1}`}
-                                href={`/estudiantes?page=${index + 1}`}
+                                href={`/estudiantes?page=${index + 1}${searchTerm ? `&filter=${searchTerm}` : ""}`}
                                 isActive={index === students.page}
                                 className="bg-background"
                             >

--- a/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListContainer.test.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListContainer.test.tsx
@@ -7,10 +7,13 @@ import { ListTeacherAssignmentsUseCase } from "@/academic/application/usecases/t
 import { TeacherAssignmentListContainer } from "./TeacherAssignmentListContainer";
 import { TeacherAssignment } from "@/academic/domain/entities/TeacherAssignment";
 import { toast } from "@/hooks/use-toast";
+import { Page } from "@/lib/utils";
 
 describe("TeacherAssignmentListContainer", () => {
   let listUseCase: ListTeacherAssignmentsUseCase = {
-    execute: vi.fn().mockResolvedValue(mockRight<TeacherAssignment[]>([])),
+    execute: vi.fn().mockResolvedValue(
+      mockRight<Page<TeacherAssignment>>({ content: [], page: 1, size: 10, total: 0, totalPage: 0 })
+    ),
   } as unknown as ListTeacherAssignmentsUseCase;
 
   beforeEach(() => {
@@ -47,9 +50,15 @@ describe("TeacherAssignmentListContainer", () => {
   it("muestra lista de asignaciones si la carga es exitosa", async () => {
     listUseCase = {
       execute: vi.fn().mockResolvedValue(
-        mockRight([
-          { id: 1, teacherId: 1, courseId: 2, subjectId: 3, schoolYearId: "2023" } as TeacherAssignment,
-        ])
+        mockRight<Page<TeacherAssignment>>({
+          content: [
+            { id: 1, teacherId: 1, courseId: 2, subjectId: 3, schoolYearId: "2023" } as TeacherAssignment,
+          ],
+          page: 1,
+          size: 10,
+          total: 1,
+          totalPage: 1,
+        })
       ),
     } as unknown as ListTeacherAssignmentsUseCase;
 

--- a/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListContainer.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListContainer.tsx
@@ -5,20 +5,32 @@ import { useInjection } from "inversify-react";
 import { useCallback, useEffect, useState } from "react";
 import { TeacherAssignment } from "@/academic/domain/entities/TeacherAssignment";
 import { toast } from "@/hooks/use-toast";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
+import { Page } from "@/lib/utils";
 
 export const TeacherAssignmentListContainer = () => {
   const listUseCase = useInjection<ListTeacherAssignmentsUseCase>(TEACHER_ASSIGNMENT_SYMBOLS.LIST_USE_CASE);
   const navigate = useNavigate();
-  const [assignments, setAssignments] = useState<TeacherAssignment[]>([]);
+  const [searchParams] = useSearchParams();
+  const page = Number(searchParams.get("page")) || 1;
+  const filter = searchParams.get("filter") || "";
+
+  const [assignments, setAssignments] = useState<Page<TeacherAssignment>>({
+    content: [],
+    page: 0,
+    size: 10,
+    total: 0,
+    totalPage: 0,
+  });
   const [loading, setLoading] = useState(false);
-  const [searchTerm, setSearchTerm] = useState("");
 
   const fetchData = useCallback(async () => {
     setLoading(true);
-    const res = await listUseCase.execute(new ListTeacherAssignmentsCommand());
+    const res = await listUseCase.execute(new ListTeacherAssignmentsCommand(page, 10));
     res
-      .ifRight(data => setAssignments(data ?? []))
+      .ifRight(data => {
+        if (data) setAssignments(data);
+      })
       .ifLeft(f =>
         toast({
           title: "Error",
@@ -27,19 +39,24 @@ export const TeacherAssignmentListContainer = () => {
         })
       );
     setLoading(false);
-  }, [listUseCase]);
+  }, [listUseCase, page]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
-  const filtered = assignments.filter(a => a.teacherId.toString().includes(searchTerm));
+  const handleSearchChange = (term: string) => {
+    navigate({ pathname: "/asignaciones-docentes", search: `?page=1&filter=${term}` });
+  };
+
+  const filtered = assignments.content.filter(a => a.teacherId.toString().includes(filter));
+  const data = { ...assignments, content: filtered };
 
   return (
     <TeacherAssignmentListPresenter
-      assignments={filtered}
+      assignments={data}
       loading={loading}
       error={null}
-      searchTerm={searchTerm}
-      onSearchChange={setSearchTerm}
+      searchTerm={filter}
+      onSearchChange={handleSearchChange}
       onAddAssignment={() => navigate("/asignaciones-docentes/nuevo")}
     />
   );

--- a/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListPresenter.test.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListPresenter.test.tsx
@@ -3,9 +3,10 @@ import { describe, it, expect, vi } from "vitest";
 import { MemoryRouter } from "react-router";
 import { TeacherAssignmentListPresenter } from "./TeacherAssignmentListPresenter";
 import { TeacherAssignment } from "@/academic/domain/entities/TeacherAssignment";
+import { Page } from "@/lib/utils";
 
 const defaultProps = {
-  assignments: [] as TeacherAssignment[],
+  assignments: { content: [], page: 0, size: 10, total: 0, totalPage: 0 } as Page<TeacherAssignment>,
   loading: false,
   error: null as string | null,
   searchTerm: "",
@@ -34,15 +35,19 @@ describe("TeacherAssignmentListPresenter", () => {
   });
 
   it("muestra asignaciones", () => {
-    const assignments: TeacherAssignment[] = [
-      { id: 1, teacherId: 1, courseId: 2, subjectId: 3, schoolYearId: "2023" },
-    ];
+    const assignments: Page<TeacherAssignment> = {
+      content: [{ id: 1, teacherId: 1, courseId: 2, subjectId: 3, schoolYearId: "2023" }],
+      page: 1,
+      size: 10,
+      total: 1,
+      totalPage: 1,
+    };
     renderPresenter({ assignments });
     expect(screen.getByText(/Docente: 1/)).toBeInTheDocument();
   });
 
   it("muestra mensaje cuando no hay asignaciones", () => {
-    renderPresenter({ assignments: [] });
+    renderPresenter({ assignments: { ...defaultProps.assignments, content: [] } });
     expect(screen.getByText("No hay asignaciones registradas aún.")).toBeInTheDocument();
   });
 });

--- a/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListPresenter.tsx
+++ b/src/academic/presentation/ui/TeacherAssignment/List/TeacherAssignmentListPresenter.tsx
@@ -6,9 +6,11 @@ import { Input } from "@/components/ui/input";
 import { Search, Plus, UserX } from "lucide-react";
 import { TeacherAssignment } from "@/academic/domain/entities/TeacherAssignment";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Pagination, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Page } from "@/lib/utils";
 
 interface Props {
-  assignments: TeacherAssignment[];
+  assignments: Page<TeacherAssignment>;
   loading: boolean;
   error: string | null;
   searchTerm: string;
@@ -33,7 +35,7 @@ export const TeacherAssignmentListPresenter = ({ assignments, loading, error, se
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {loading && <Skeleton role="status" className="h-24 w-full col-span-full" />}
           {error && <div className="text-destructive text-center col-span-full">{error}</div>}
-          {assignments.map(a => (
+          {assignments.content.map(a => (
             <Card key={a.id} className="hover:shadow-md transition-shadow">
               <CardContent className="p-4">
                 <p className="font-semibold">Docente: {a.teacherId}</p>
@@ -42,8 +44,25 @@ export const TeacherAssignmentListPresenter = ({ assignments, loading, error, se
               </CardContent>
             </Card>
           ))}
+          <Pagination className="col-span-full justify-center">
+            <PaginationPrevious className="bg-background" />
+            {assignments.total > 1 && Array.from({ length: assignments.totalPage }).map((_, index) => (
+              <PaginationLink
+                key={`page-${index + 1}`}
+                href={`/asignaciones-docentes?page=${index + 1}`}
+                isActive={index === assignments.page}
+                className="bg-background"
+              >
+                {index + 1}
+              </PaginationLink>
+            ))}
+            <PaginationNext className="bg-background" />
+          </Pagination>
+          <div className="col-span-full text-center text-sm text-muted-foreground">
+            Página {assignments.page} de {assignments.totalPage} - Total de asignaciones: {assignments.total}
+          </div>
         </div>
-        {assignments.length === 0 && !loading && !error && (
+        {assignments.content.length === 0 && !loading && !error && (
           <div className="col-span-3 text-center py-8 text-muted-foreground w-full flex flex-col items-center space-y-4">
             <UserX className="h-12 w-12 text-muted-foreground" />
             <p className="text-lg font-medium">

--- a/src/academic/presentation/ui/TeacherPlanning/List/TeacherPlanningListPresenter.tsx
+++ b/src/academic/presentation/ui/TeacherPlanning/List/TeacherPlanningListPresenter.tsx
@@ -3,12 +3,14 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, Plus } from "lucide-react";
+import { Search, Plus, ClipboardX } from "lucide-react";
 import { TeacherPlanning } from "@/academic/domain/entities/TeacherPlanning";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Pagination, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Page } from "@/lib/utils";
 
 interface Props {
-  plannings: TeacherPlanning[];
+  plannings: Page<TeacherPlanning>;
   loading: boolean;
   error: string | null;
   searchTerm: string;
@@ -28,12 +30,17 @@ export const TeacherPlanningListPresenter = ({ plannings, loading, error, search
       <CardContent>
         <div className="flex items-center gap-2 mb-6">
           <Search className="h-4 w-4 text-muted-foreground" />
-          <Input placeholder="Buscar por tema" value={searchTerm} onChange={e => onSearchChange(e.target.value)} className="max-w-sm" />
+          <Input
+            placeholder="Buscar por tema"
+            value={searchTerm}
+            onChange={e => onSearchChange(e.target.value)}
+            className="max-w-sm"
+          />
         </div>
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {loading && <Skeleton className="h-24 w-full col-span-full" />}
+          {loading && <Skeleton role="status" className="h-24 w-full col-span-full" />}
           {error && <div className="text-destructive text-center col-span-full">{error}</div>}
-          {plannings.map(p => (
+          {plannings.content.map(p => (
             <Card key={p.id} className="hover:shadow-md transition-shadow">
               <CardContent className="p-4">
                 <p className="font-semibold">{p.topic}</p>
@@ -43,7 +50,36 @@ export const TeacherPlanningListPresenter = ({ plannings, loading, error, search
             </Card>
           ))}
         </div>
-        {plannings.length === 0 && !loading && !error && <div className="text-center py-8 text-muted-foreground">No se encontraron planificaciones</div>}
+        {plannings.content.length === 0 && !loading && !error && (
+          <div className="col-span-3 text-center py-8 text-muted-foreground w-full flex flex-col items-center space-y-4">
+            <ClipboardX className="h-12 w-12 text-muted-foreground" />
+            <p className="text-lg font-medium">
+              {searchTerm
+                ? `No encontramos resultados para "${searchTerm}".`
+                : "No hay planificaciones registradas aún."}
+            </p>
+            {!searchTerm && <Button onClick={onAddPlanning}>Nueva</Button>}
+          </div>
+        )}
+
+        <Pagination className="col-span-full justify-center">
+          <PaginationPrevious className="bg-background" />
+          {plannings.totalPage > 1 &&
+            Array.from({ length: plannings.totalPage }).map((_, index) => (
+              <PaginationLink
+                key={`page-${index + 1}`}
+                href={`/planificaciones-docentes?page=${index + 1}${searchTerm ? `&filter=${searchTerm}` : ""}`}
+                isActive={index === plannings.page}
+                className="bg-background"
+              >
+                {index + 1}
+              </PaginationLink>
+            ))}
+          <PaginationNext className="bg-background" />
+        </Pagination>
+        <div className="col-span-full text-center text-sm text-muted-foreground">
+          Página {plannings.page} de {plannings.totalPage} - Total de planificaciones: {plannings.total}
+        </div>
       </CardContent>
     </Card>
   </div>


### PR DESCRIPTION
## Summary
- paginate behavior reports with shared Page contracts
- add UI pagination and search to behavior report list
- enable server-side search pagination for student and representative lists
- add pageable enrollment and attendance repositories with paginated UIs
- add pagination to meeting, assessment, teacher planning, and promotion act modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c63f24003083308d97451c27b5a074